### PR TITLE
Next

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,8 @@ libcve_la_SOURCES = \
 	library/cve-check-tool.h \
 	library/cve-string.h \
 	library/cve-string.c \
+	library/cve-db-lock.h \
+	library/cve-db-lock.c \
 	library/fetch.c \
 	library/fetch.h \
 	library/template.c \

--- a/src/core.c
+++ b/src/core.c
@@ -32,8 +32,8 @@
 
 #include <sqlite3.h>
 
-#define YEAR_START 2002
-#define URI_PREFIX "http://static.nvd.nist.gov/feeds/xml/cve"
+const char nvd_file[] = "nvd.db";
+const char nvd_dir[] = "NVDS";
 
 struct CveDB {
         /** XML traversal state */

--- a/src/core.h
+++ b/src/core.h
@@ -13,6 +13,9 @@
 #include <libxml/xmlreader.h>
 #include "common.h"
 
+extern const char nvd_file[];        /* nvd.db */
+extern const char nvd_dir[];         /* NVDS */
+
 /**
  * A CVE Database, using the National Vulnerability Database as its source
  */

--- a/src/library/cve-db-lock.c
+++ b/src/library/cve-db-lock.c
@@ -24,6 +24,7 @@
 #include <assert.h>
 
 #include "core.h"
+#include "util.h"
 #include "cve-db-lock.h"
 
 static const short int locktype2l_type[] = {
@@ -47,38 +48,14 @@ bool cve_db_lock_init(const char *db_path)
 {
         const int flags = O_RDWR|O_CREAT|O_NONBLOCK|O_NOFOLLOW;
         const mode_t mode = S_IRUSR|S_IWUSR;
-        const char *dir;
-        char *file, *path;
-        int ret;
 
         assert(db_lock_fd == -1);
         assert(db_lock_fname == NULL);
         assert(db_path != NULL);
 
-        path = strdup(db_path);
-        if (!path)
-                return false;
-
-        file = strrchr(path, '/');
-        if (file) {
-                *file++ = '\0';
-                if (!*file)
-                        file = (char *) nvd_file;
-                dir = *path ? path : ".";
-        } else {
-                file = path;
-                dir = ".";
-        }
-
-        ret = asprintf(&db_lock_fname, "%s/.%s.cve.lock", dir, file);
-        if (ret == -1) {
-                /* db_lock_fname contents undefined: force to NULL */
-                db_lock_fname = NULL;
-        } else {
+        db_lock_fname = get_db_dot_fname(db_path, "cve.lock");
+        if (db_lock_fname)
                 db_lock_fd = open(db_lock_fname, flags, mode);
-        }
-
-        free(path);
 
         return db_lock_fd != -1;
 }

--- a/src/library/cve-db-lock.c
+++ b/src/library/cve-db-lock.c
@@ -1,0 +1,179 @@
+/*
+ * cve-check-tool.c
+ *
+ * Copyright (C) 2015-2016 Sergey Popovich <popovich_sergei@mail.ua>.
+ *
+ * cve-check-tool is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#define _GNU_SOURCE
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <assert.h>
+
+#include "core.h"
+#include "cve-db-lock.h"
+
+static const short int locktype2l_type[] = {
+        [LT_READ]       = F_RDLCK,
+        [LT_WRITE]      = F_WRLCK,
+};
+
+static const char locktype2string[][sizeof("write")] = {
+        [LT_READ]       = "read",
+        [LT_WRITE]      = "write",
+};
+
+static int db_lock_fd = -1;
+static char *db_lock_fname;
+
+#ifndef O_NOFOLLOW
+#define O_NOFOLLOW      0
+#endif
+
+bool cve_db_lock_init(const char *db_path)
+{
+        const int flags = O_RDWR|O_CREAT|O_NONBLOCK|O_NOFOLLOW;
+        const mode_t mode = S_IRUSR|S_IWUSR;
+        const char *dir;
+        char *file, *path;
+        int ret;
+
+        assert(db_lock_fd == -1);
+        assert(db_lock_fname == NULL);
+        assert(db_path != NULL);
+
+        path = strdup(db_path);
+        if (!path)
+                return false;
+
+        file = strrchr(path, '/');
+        if (file) {
+                *file++ = '\0';
+                if (!*file)
+                        file = (char *) nvd_file;
+                dir = *path ? path : ".";
+        } else {
+                file = path;
+                dir = ".";
+        }
+
+        ret = asprintf(&db_lock_fname, "%s/.%s.cve.lock", dir, file);
+        if (ret == -1) {
+                /* db_lock_fname contents undefined: force to NULL */
+                db_lock_fname = NULL;
+        } else {
+                db_lock_fd = open(db_lock_fname, flags, mode);
+        }
+
+        free(path);
+
+        return db_lock_fd != -1;
+}
+
+void cve_db_lock_fini(void)
+{
+        assert(db_lock_fd != -1);
+        assert(db_lock_fname != NULL);
+
+        close(db_lock_fd);
+        db_lock_fd = -1;
+
+        unlink(db_lock_fname);
+        free(db_lock_fname);
+        db_lock_fname = NULL;
+}
+
+bool cve_db_lock(enum locktype lt, int wait)
+{
+        const char *lt_str = locktype2string[lt];
+        unsigned int waited;
+
+        assert(db_lock_fd != -1);
+
+        if (wait < 0)
+                waited = wait = 2;
+        else
+                waited = 0;
+
+        do {
+                struct flock fl = {
+                        .l_type         = locktype2l_type[lt],
+                        .l_whence       = SEEK_SET,
+                };
+                int ret;
+
+                ret = fcntl(db_lock_fd, F_SETLK, &fl);
+                if (!ret)
+                        return true;
+                if (errno != EAGAIN && errno != EACCES) {
+                        fprintf(stderr,
+                                "Error acquiring database lock: %s\n",
+                                strerror(errno));
+                        break;
+                }
+
+                if (waited % 2)
+                        goto sleep;
+                fputs("Another app holds the lock on database", stderr);
+                if (wait) {
+                        int remaining = wait - waited;
+                        if (remaining <= 0) {
+                                fprintf(stderr,
+                                        "; %s lock is not acquired\n", lt_str);
+                                break;
+                        }
+                        fprintf(stderr,
+                                "; acquiring %s lock within %ds ...",
+                                lt_str, remaining);
+                } else {
+                        fputs("; waiting indefinitely", stderr);
+                }
+                fputc('\n', stderr);
+sleep:
+                sleep(1);
+                waited++;
+                if (wait && waited >= (unsigned int) wait)
+                        waited = (wait + 1) & ~1; /* last round: make it even */
+        } while (1);
+
+        return false;
+}
+
+void cve_db_unlock(void)
+{
+        struct flock fl = {
+                .l_type         = F_UNLCK,
+                .l_whence       = SEEK_SET,
+        };
+        int ret;
+
+        ret = fcntl(db_lock_fd, F_SETLK, &fl);
+
+        assert(ret == 0);
+}
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/src/library/cve-db-lock.h
+++ b/src/library/cve-db-lock.h
@@ -1,0 +1,97 @@
+/*
+ * cve-check-tool.h
+ *
+ * Copyright (C) 2015-2016 Sergey Popovich <popovich_sergei@mail.ua>.
+ *
+ * cve-check-tool is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <stdbool.h>
+
+/**
+ * Enumerate to represent possible locking types to imply on the
+ * database file
+ */
+enum locktype {
+        LT_READ         = 0,            /**<Shared lock type */
+        LT_WRITE,                       /**<Exclusive lock type */
+};
+
+enum {
+        LOCK_WAIT_SECS  = 5 * 60,       /**<Wait for lock to aquire 5 minutes */
+};
+
+/**
+ * Initialize lock on the database by opening it's file and saving
+ * descriptor for later use by other locking functions
+ *
+ * @note If database file does not exists it will be created
+ *
+ * @param db_file Database file to operate on
+ * @return True if database file opened successfuly and false overwise
+ */
+bool cve_db_lock_init(const char *db_file);
+
+/**
+ * Finalizes lock usage on database file by closing corresponding
+ * file descriptor
+ *
+ * @note Any locking, if applied to the file descriptor will be released
+ */
+void cve_db_lock_fini(void);
+
+/**
+ * Try to aquire lock of the given type on the previously initialized
+ * database file descriptor within given timeout
+ *
+ * @param lt Lock type to aquire as specified by the enum locktype
+ * @param wait Number of seconds to wait for lock before giving up
+ * If specified as < 0 then return immediately, 0 means wait
+ * indefinitely to aquire lock.
+ */
+bool cve_db_lock(enum locktype lt, int wait);
+
+/**
+ * Helper routine to aquire shared (read) lock within given timeout
+ *
+ * @note Calls cve_db_lock() with LT_READ to perform real work
+ *
+ * @param wait Number of seconds to wait for lock before giving up
+ */
+static inline bool cve_db_read_lock(int wait)
+{
+        return cve_db_lock(LT_READ, wait);
+}
+
+/**
+ * Helper routine to aquire exclusive (write) lock within given timeout
+ *
+ * @note Calls cve_db_lock() with LT_WRITE to perform real work
+ *
+ * @param wait Number of seconds to wait for lock before giving up
+ */
+static inline bool cve_db_write_lock(int wait)
+{
+        return cve_db_lock(LT_WRITE, wait);
+}
+
+/**
+ * Releases previously aquired lock from database file
+ */
+void cve_db_unlock(void);
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/src/library/util.c
+++ b/src/library/util.c
@@ -30,8 +30,6 @@
 
 #define streq(x,y) strcmp(x,y) == 0
 
-DEF_AUTOFREE(char, free)
-
 bool find_sources(const char *path, package_match_func match, bool recurse, cve_add_callback cb)
 {
         struct stat st = {.st_ino = 0};

--- a/src/library/util.c
+++ b/src/library/util.c
@@ -327,6 +327,39 @@ char *cve_get_file_parent(const char *p)
         return dirname(r);
 }
 
+char *get_db_dot_fname(const char *db_path, const char *suffix)
+{
+        autofree(char) *path = NULL;
+        char *dot_fname;
+        int ret = -1;
+
+        path = strdup(db_path);
+        if (path) {
+                const char *dir;
+                char *file;
+
+                file = strrchr(path, '/');
+                if (file) {
+                        *file++ = '\0';
+                        if (!*file)
+                                file = (char *) nvd_file;
+                        dir = *path ? path : ".";
+                } else {
+                        file = path;
+                        dir = ".";
+                }
+
+                ret = asprintf(&dot_fname, "%s/.%s.%s", dir, file, suffix);
+        }
+
+        if (ret == -1) {
+                /* dot_fname contents undefined on error: force to NULL */
+                dot_fname = NULL;
+        }
+
+        return dot_fname;
+}
+
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
  *

--- a/src/library/util.h
+++ b/src/library/util.h
@@ -165,6 +165,7 @@ DEF_AUTOFREE(GZlibDecompressor, g_object_unref)
 DEF_AUTOFREE(GKeyFile, g_key_file_unref)
 DEF_AUTOFREE(cve_string, cve_string_free)
 DEF_AUTOFREE(CveDB, cve_db_free)
+DEF_AUTOFREE(char, free)
 
 /**
  * Suger-utility: Determine if a string contains a certain word

--- a/src/library/util.h
+++ b/src/library/util.h
@@ -271,6 +271,15 @@ bool cve_is_dir(const char *p);
  */
 char *cve_get_file_parent(const char *p);
 
+/**
+ * Return absolute path to the dot file in format .basename(db_path).suffix
+ *
+ * @note This is an allocated string, and must be freed by the caller
+ * @param db_path Path to the database directory
+ * @return a newly allocated string or NULL in case of error
+ */
+char *get_db_dot_fname(const char *db_path, const char *suffix);
+
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
  *

--- a/src/main.c
+++ b/src/main.c
@@ -581,10 +581,6 @@ int main(int argc, char **argv)
         self->show_unaffected = show_unaffected;
         instance.db = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, package_free);
         instance.bdb = NULL;
-        /* Automatically disable HTML output in CSV mode */
-        if (csv_mode) {
-                no_html = true;
-        }
 
         cve_plugin_manager_init();
 
@@ -718,32 +714,23 @@ clean:
          */
         if (csv_mode) {
                 report = cve_plugin_get_by_name("csv");
+        } else if (!no_html) {
+                report = cve_plugin_get_by_name("html");
         } else {
                 report = cve_plugin_get_by_name("cli");
         }
+
         if (!report || !report->report) {
                 fprintf(stderr, "No usable output module\n");
                 goto cleanup;
         }
 
         if (!report->report(self)) {
+                fprintf(stderr, "Report generation failed\n");
                 goto cleanup;
         }
 
-        if (!no_html) {
-                report = cve_plugin_get_by_name("html");
-                if (!report || !report->report) {
-                        fprintf(stderr, "html module is missing\n");
-                        goto cleanup;
-                }
-                if (!report->report(self)) {
-                        fprintf(stderr, "Report generation failed\n");
-                } else {
-                        ret = EXIT_SUCCESS;
-                }
-        } else {
-                ret = EXIT_SUCCESS;
-        }
+        ret = EXIT_SUCCESS;
 
 cleanup:
         cve_plugin_manager_destroy();

--- a/src/main.c
+++ b/src/main.c
@@ -426,6 +426,7 @@ int main(int argc, char **argv)
         time_t ti;
         CvePlugin *report = NULL;
         LIBXML_TEST_VERSION
+        bool quiet;
 
         self = &instance;
         context = g_option_context_new(" - cve check tool");
@@ -434,6 +435,8 @@ int main(int argc, char **argv)
                 g_printerr("Invalid options: %s\n", error->message);
                 goto cleanup;
         }
+
+        quiet = csv_mode || !no_html;
 
         if (_show_version) {
                 show_version();
@@ -455,7 +458,7 @@ int main(int argc, char **argv)
                 }
                 if (status) {
                         fprintf(stderr, "Update of db forced\n");
-                        if (!update_db(csv_mode, db_path)) {
+                        if (!update_db(quiet, db_path)) {
                                 fprintf(stderr, "DB update failure\n");
                                 goto cleanup;
                         }
@@ -701,7 +704,7 @@ clean:
                 goto cleanup;
         }
         /* Consider a verbosity flag... */
-        if (!csv_mode) {
+        if (!quiet) {
                 fprintf(stderr, "Scanned %d source file%s\n", size, size > 1 ? "s" : "");
         }
 

--- a/src/main.c
+++ b/src/main.c
@@ -32,6 +32,7 @@
 #include "plugins/jira/jira.h"
 #include "config.h"
 #include "cve-string.h"
+#include "cve-db-lock.h"
 #include "core.h"
 
 #include "update.h"
@@ -424,14 +425,14 @@ int main(int argc, char **argv)
         time_t ti;
         CvePlugin *report = NULL;
         LIBXML_TEST_VERSION
-        bool quiet;
+        bool quiet, db_locked;
 
         self = &instance;
         context = g_option_context_new(" - cve check tool");
         g_option_context_add_main_entries(context, _entries, NULL);
         if (!g_option_context_parse(context, &argc, &argv, &error)) {
                 g_printerr("Invalid options: %s\n", error->message);
-                goto cleanup;
+                goto cleanup_no_lock;
         }
 
         quiet = csv_mode || !no_html;
@@ -439,12 +440,24 @@ int main(int argc, char **argv)
         if (_show_version) {
                 show_version();
                 ret = EXIT_SUCCESS;
-                goto cleanup;
+                goto cleanup_no_lock;
         }
 
         db_path = get_db_path(nvds);
         if (!db_path) {
                 fprintf(stderr, "main(): Out of memory\n");
+                goto cleanup_no_lock;
+        }
+
+        db_locked = cve_db_lock_init(db_path);
+        if (!db_locked) {
+                fprintf(stderr, "Not continuing without a database %s\n", "lock");
+                goto cleanup_no_lock;
+        }
+
+        db_locked = cve_db_read_lock(LOCK_WAIT_SECS);
+        if (!db_locked) {
+                fputs("Exiting...\n", stderr);
                 goto cleanup;
         }
 
@@ -456,6 +469,7 @@ int main(int argc, char **argv)
                 }
                 if (status) {
                         fprintf(stderr, "Update of db forced\n");
+                        cve_db_unlock();
                         if (!update_db(quiet, db_path)) {
                                 fprintf(stderr, "DB update failure\n");
                                 goto cleanup;
@@ -463,7 +477,7 @@ int main(int argc, char **argv)
                 }
         } else {
                 if (!cve_file_exists(db_path)) {
-                        fprintf(stderr, "Not continuing without a database\n");
+                        fprintf(stderr, "Not continuing without a database %s\n", "file");
                         goto cleanup;
                 }
         }
@@ -734,6 +748,9 @@ clean:
         ret = EXIT_SUCCESS;
 
 cleanup:
+        cve_db_lock_fini();
+
+cleanup_no_lock:
         cve_plugin_manager_destroy();
         if (instance.db) {
                 g_hash_table_unref(instance.db);

--- a/src/main.c
+++ b/src/main.c
@@ -406,15 +406,6 @@ static bool track_bugs(const gchar *auto_bug_template)
         return NULL;
 }
 
-static char *get_db_path(void)
-{
-        char *p = NULL;
-        if (!asprintf(&p, "%s/NVDS/nvd.db", g_get_home_dir())) {
-                return NULL;
-        }
-        return p;
-}
-
 /**
  * Main entry.
  */
@@ -424,9 +415,8 @@ int main(int argc, char **argv)
         autofree(GOptionContext) *context = NULL;
         autofree(char) *target = NULL;
         autofree(GKeyFile) *config = NULL;
-        autofree(char) *db_path = NULL;
+        autofree(gchar) *db_path = NULL;
         autofree(CveDB) *cve_db = NULL;
-        autofree(gchar) *lockfile = NULL;
         int ret = EXIT_FAILURE;
         PackageType type = PACKAGE_TYPE_UNKNOWN;
         CveCheckTool instance = {.is_patched = 0};
@@ -449,21 +439,21 @@ int main(int argc, char **argv)
                 goto cleanup;
         }
 
-        db_path = get_db_path();
+        db_path = get_db_path(NULL);
         if (!db_path) {
-                fprintf(stderr, "main(): Out of memory\n");
-                goto cleanup;
-        }
-        lockfile = get_lock_file();
-        if (!lockfile) {
                 fprintf(stderr, "main(): Out of memory\n");
                 goto cleanup;
         }
 
         if (!skip_update) {
-                if (update_required() || cve_file_exists(lockfile)) {
+                int status = update_required(db_path);
+                if (status == -1) {
+                        fprintf(stderr, "Failed to check if db requires update\n");
+                        goto cleanup;
+                }
+                if (status) {
                         fprintf(stderr, "Update of db forced\n");
-                        if (!update_db(csv_mode)) {
+                        if (!update_db(csv_mode, db_path)) {
                                 fprintf(stderr, "DB update failure\n");
                                 goto cleanup;
                         }

--- a/src/main.c
+++ b/src/main.c
@@ -47,8 +47,6 @@ static char *srpm_dir = NULL;
 
 #define SUPPORTED_TYPES "eopkg, rpm, srpm, pkgbuild, faux"
 
-DEF_AUTOFREE(char, free)
-
 #define streq(x,y) strcmp(x,y) == 0
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -227,6 +227,7 @@ static bool hide_patched = false;
 static bool show_unaffected = false;
 static bool _show_version = false;
 static bool skip_update = false;
+static gchar *nvds = NULL;
 static gchar *forced_type = NULL;
 static bool no_html = false;
 static bool csv_mode = false;
@@ -239,6 +240,7 @@ static GOptionEntry _entries[] = {
         { "not-patched", 'n', 0, G_OPTION_ARG_NONE, &hide_patched, "Hide patched/addressed CVEs", NULL },
         { "not-affected", 'a', 0, G_OPTION_ARG_NONE, &show_unaffected, "Show unaffected items", NULL },
         { "skip-update", 'u', 0, G_OPTION_ARG_NONE, &skip_update, "Bypass forced updates", NULL },
+        { "nvd-dir", 'd', 0, G_OPTION_ARG_STRING, &nvds, "NVD directory in filesystem", NULL },
         { "version", 'v', 0, G_OPTION_ARG_NONE, &_show_version, "Show version", NULL },
         { "type", 't', 0, G_OPTION_ARG_STRING, &forced_type, "Set package type to T", "T" },
         { "no-html", 'N', 0, G_OPTION_ARG_NONE, &no_html, "Disable HTML report", NULL },
@@ -439,7 +441,7 @@ int main(int argc, char **argv)
                 goto cleanup;
         }
 
-        db_path = get_db_path(NULL);
+        db_path = get_db_path(nvds);
         if (!db_path) {
                 fprintf(stderr, "main(): Out of memory\n");
                 goto cleanup;

--- a/src/output/cli.c
+++ b/src/output/cli.c
@@ -35,22 +35,23 @@ static bool cli_write_report(CveCheckTool *self)
                 if (!v->issues && self->hide_patched) {
                         continue;
                 }
-                fprintf(stderr, "%s %s (%u patched, %u issues)\n"C_WHITE"------------"C_RESET"\n", key, (char*)v->version, g_list_length(v->patched), g_list_length(v->issues));
+                fprintf(stdout, "%s %s (%u patched, %u issues)\n"C_WHITE"------------"C_RESET"\n",
+                        key, (char*)v->version, g_list_length(v->patched), g_list_length(v->issues));
                 for (c = v->issues; c; c = c->next) {
                         entry = cve_db_get_cve(self->cve_db, (gchar*)c->data);
                         if (self->modified > 0 && entry->modified > self->modified) {
                                 cve_free(entry);
                                 continue;
                         }
-                        fprintf(stderr, " * "C_RED"%s"C_RESET" : %s\n\n", (char*)c->data, entry->summary);
+                        fprintf(stdout, " * "C_RED"%s"C_RESET" : %s\n\n", (char*)c->data, entry->summary);
                         /* Print links.. */
                         bool p = false;
                         for (t = entry->uris; t; t = t->next) {
-                                fprintf(stderr, "     - %s\n", (char*)t->data);
+                                fprintf(stdout, "     - %s\n", (char*)t->data);
                                 p = true;
                         }
                         if (p) {
-                                fprintf(stderr, "\n");
+                                fprintf(stdout, "\n");
                         }
                         cve_free(entry);
                 }
@@ -61,11 +62,11 @@ static bool cli_write_report(CveCheckTool *self)
                                         cve_free(entry);
                                         continue;
                                 }
-                                fprintf(stderr, " * "C_BLUE"%s [PATCHED]"C_RESET" : %s\n\n", (char*)c->data, entry->summary);
+                                fprintf(stdout, " * "C_BLUE"%s [PATCHED]"C_RESET" : %s\n\n", (char*)c->data, entry->summary);
                                 cve_free(entry);
                         }
                 }
-                fprintf(stderr, "\n");
+                fputc('\n', stdout);
         }
         return true;
 }

--- a/src/output/html.c
+++ b/src/output/html.c
@@ -11,6 +11,10 @@
 
 #define _GNU_SOURCE
 
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+
 #include "config.h"
 #include "util.h"
 #include "template.h"
@@ -72,10 +76,9 @@ static inline gchar *status_map(ReportStatus status)
 
 static bool write_report(CveCheckTool *self)
 {
-        autofree(GError) *error = NULL;
         autofree(gchar) *aff = NULL;
         autofree(gchar) *body = NULL;
-        autofree(gchar) *ret = NULL;
+        autofree(gchar) *report = NULL;
         GHashTableIter iter;
         gchar *key = NULL;
         struct source_package_t *v = NULL;
@@ -84,7 +87,7 @@ static bool write_report(CveCheckTool *self)
         gint affected = 0;
         guint row = 0;
         autofree(TemplateContext) *context = NULL;
-        const char *filename = "report.html";
+        int ret;
 
         /* Mandatory template files */
         LOAD_TEMPLATE(TMPL_TOTAL, &body);
@@ -166,11 +169,16 @@ static bool write_report(CveCheckTool *self)
                 affected > 1 ? "s" : "");
 
         template_context_add_string(context, "affected_string", aff);
-        ret = template_context_process_line(context, body, false);
+        report = template_context_process_line(context, body, false);
 
-        /* Write file */
-        if (!g_file_set_contents(filename, ret, -1, &error)) {
-                g_printerr("Unable to write report: %s\n", error->message);
+        /* Write report */
+        ret = printf("%s\n", report);
+        if (ret < 0) {
+                g_printerr("Unable to write report: %s\n", strerror(errno));
+                return false;
+        }
+        if (!ret || ret != strlen(report) + 1) {
+                g_printerr("Report was truncated\n");
                 return false;
         }
 

--- a/src/update-main.c
+++ b/src/update-main.c
@@ -39,10 +39,12 @@ the Free Software Foundation; either version 2 of the License, or\n\
         fprintf(stderr, "%s\n", msg);
 }
 
+static gchar *nvds = NULL;
 static bool _show_version = false;
 static bool _quiet = false;
 
 static GOptionEntry _entries[] = {
+        { "nvd-dir", 'd', 0, G_OPTION_ARG_STRING, &nvds, "NVD directory in filesystem", NULL },
         { "version", 'v', 0, G_OPTION_ARG_NONE, &_show_version, "Show version", NULL },
         { "quiet", 'q', 0, G_OPTION_ARG_NONE, &_quiet, "Run silently", NULL },
         { .short_name = 0 }
@@ -72,7 +74,7 @@ int main(int argc, char **argv)
                 goto end;
         }
 
-        db_path = get_db_path(NULL);
+        db_path = get_db_path(nvds);
         if (!db_path) {
                 fprintf(stderr, "main(): Out of memory\n");
                 goto end;

--- a/src/update-main.c
+++ b/src/update-main.c
@@ -23,6 +23,7 @@
 #include "util.h"
 #include "config.h"
 #include "cve-string.h"
+#include "cve-db-lock.h"
 #include "core.h"
 
 #include "update.h"
@@ -59,6 +60,7 @@ int main(int argc, char **argv)
         autofree(GOptionContext) *context = NULL;
         autofree(gchar) *db_path = NULL;
         int ret = EXIT_FAILURE;
+        bool db_locked;
 
         LIBXML_TEST_VERSION
         context = g_option_context_new(" - cve update");
@@ -80,6 +82,12 @@ int main(int argc, char **argv)
                 goto end;
         }
 
+        db_locked = cve_db_lock_init(db_path);
+        if (!db_locked) {
+                fputs("Not continuing without a database lock\n", stderr);
+                goto end;
+        }
+
         if (update_db(_quiet, db_path)) {
                 ret = EXIT_SUCCESS;
         } else {
@@ -87,6 +95,7 @@ int main(int argc, char **argv)
         }
 
 end:
+        cve_db_lock_fini();
         xmlCleanupParser();
         return ret;
 }

--- a/src/update-main.c
+++ b/src/update-main.c
@@ -55,6 +55,7 @@ int main(int argc, char **argv)
 {
         autofree(GError) *error = NULL;
         autofree(GOptionContext) *context = NULL;
+        autofree(gchar) *db_path = NULL;
         int ret = EXIT_FAILURE;
 
         LIBXML_TEST_VERSION
@@ -71,7 +72,13 @@ int main(int argc, char **argv)
                 goto end;
         }
 
-        if (update_db(_quiet)) {
+        db_path = get_db_path(NULL);
+        if (!db_path) {
+                fprintf(stderr, "main(): Out of memory\n");
+                goto end;
+        }
+
+        if (update_db(_quiet, db_path)) {
                 ret = EXIT_SUCCESS;
         } else {
                 fprintf(stderr, "Failed to update database\n");

--- a/src/update.c
+++ b/src/update.c
@@ -124,11 +124,9 @@ static inline int update_begin(const char *update_fname)
 
 static inline void update_end(int fd, const char *update_fname, bool ok)
 {
-        if (fd != -1) {
-                close(fd);
-                if (ok)
-                        unlink(update_fname);
-        }
+        close(fd);
+        if (ok)
+                unlink(update_fname);
 }
 
 int update_required(const gchar *db_file)
@@ -147,29 +145,25 @@ bool update_db(bool quiet, const gchar *db_file)
         int year;
         bool ret = false;
         bool db_exist = false;
-        bool db_locked;
+        bool db_locked = false;
 
         u_fname = get_db_dot_fname(db_file, UPDATE_DB_FNAME_SUFFIX);
-        if (!u_fname) {
-                fputs("update_db(): Out of memory\n", stderr);
-                goto end_no_lock;
-        }
+        if (!u_fname)
+                goto oom;
+
+        db_dir = g_path_get_dirname(db_file);
+        if (!db_dir)
+                goto oom;
 
         db_locked = cve_db_write_lock(LOCK_WAIT_SECS);
         if (!db_locked) {
                 fputs("Exiting...\n", stderr);
-                goto end_no_lock;
+                goto end;
         }
 
         /* Lock aquired, check if database is still needs update */
         if (!__update_required(db_file, u_fname)) {
                 ret = true;
-                goto end;
-        }
-
-        db_dir = g_path_get_dirname(db_file);
-        if (!db_dir) {
-                fprintf(stderr, "update_db(): Out of memory\n");
                 goto end;
         }
 
@@ -206,7 +200,12 @@ bool update_db(bool quiet, const gchar *db_file)
                 }
 
                 uri = g_strdup_printf("%s/%s", nvd_uri, nvdcve);
+                if (!uri)
+                        goto oom;
+
                 target = g_build_path(G_DIR_SEPARATOR_S, db_dir, nvdcve, NULL);
+                if (!target)
+                        goto oom;
 
                 st = fetch_uri(uri, target, !quiet);
                 switch (st) {
@@ -248,10 +247,14 @@ bool update_db(bool quiet, const gchar *db_file)
 
         ret = true;
 end:
-        update_end(u_handle, u_fname, ret);
-        cve_db_unlock();
-end_no_lock:
+        if (u_handle != -1)
+                update_end(u_handle, u_fname, ret);
+        if (db_locked)
+                cve_db_unlock();
         return ret;
+oom:
+        fputs("main(): Out of memory\n", stderr);
+        goto end;
 }
 
 /*

--- a/src/update.c
+++ b/src/update.c
@@ -71,6 +71,33 @@ end:
         return ret;
 }
 
+static gchar *nvdcve_get_fname(int year, const gchar *fext)
+{
+        if (year == -1)
+                return g_strdup_printf("nvdcve-2.0-Modified.%s", fext);
+        else
+                return g_strdup_printf("nvdcve-2.0-%d.%s", year, fext);
+}
+
+/* Returning NULL does not mean that @p_fname parameter is NULL too:
+ * either declare variable whose address supplied in @p_fname as autofree()
+ * or use g_free() explicitely.
+ */
+static gchar *__nvdcve_get_pname(int year, const gchar *db_dir,
+                                 const gchar *fext, gchar **p_fname)
+{
+        *p_fname = nvdcve_get_fname(year, fext);
+        if (!*p_fname)
+                return NULL;
+        return g_build_path(G_DIR_SEPARATOR_S, db_dir, *p_fname, NULL);
+}
+
+static gchar *nvdcve_get_pname(int year, const gchar *db_dir, const gchar *fext)
+{
+        autofree(gchar) *fname = NULL;
+        return __nvdcve_get_pname(year, db_dir, fext, &fname);
+}
+
 static bool __update_required(const gchar *db_file, const gchar *update_fname)
 {
         struct stat st;
@@ -187,24 +214,17 @@ bool update_db(bool quiet, const gchar *db_file)
         for (int i = YEAR_START; i <= year+1; i++) {
                 autofree(gchar) *uri = NULL;
                 autofree(gchar) *target = NULL;
+                autofree(gchar) *nvd_xml_gz = NULL;
                 FetchStatus st;
                 bool update = false;
-                gchar _nvdcve[sizeof("nvdcve-2.0-YYYY.xml.gz")];
-                const gchar *nvdcve;
 
-                if (i > year) {
-                        nvdcve = "nvdcve-2.0-Modified.xml.gz";
-                } else {
-                        g_snprintf(_nvdcve, sizeof(_nvdcve), "nvdcve-2.0-%d.xml.gz", i);
-                        nvdcve = _nvdcve;
-                }
-
-                uri = g_strdup_printf("%s/%s", nvd_uri, nvdcve);
-                if (!uri)
+                target = __nvdcve_get_pname(i > year ? -1 : i, db_dir,
+                                            "xml.gz", &nvd_xml_gz);
+                if (!target)
                         goto oom;
 
-                target = g_build_path(G_DIR_SEPARATOR_S, db_dir, nvdcve, NULL);
-                if (!target)
+                uri = g_strdup_printf("%s/%s", nvd_uri, nvd_xml_gz);
+                if (!uri)
                         goto oom;
 
                 st = fetch_uri(uri, target, !quiet);
@@ -217,7 +237,7 @@ bool update_db(bool quiet, const gchar *db_file)
                                 break;
                         default:
                                 if (!quiet) {
-                                        fprintf(stderr, "Skipping: %s\n", basename(target));
+                                        fprintf(stderr, "Skipping: %s\n", nvd_xml_gz);
                                 }
                                 break;
                 }
@@ -232,7 +252,7 @@ bool update_db(bool quiet, const gchar *db_file)
                                 goto end;
                         }
                         if (!quiet) {
-                                fprintf(stderr, "Loaded: %s\n", basename(target));
+                                fprintf(stderr, "Loaded: %s\n", nvd_xml_gz);
                         }
                 }
         }

--- a/src/update.c
+++ b/src/update.c
@@ -20,6 +20,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <utime.h>
+#include <errno.h>
 #include <glib.h>
 #include <gio/gio.h>
 #include <curl/curl.h>
@@ -43,13 +44,31 @@
 
 gchar *get_db_path(const gchar *path)
 {
-        const gchar *nvds = "";
+        const mode_t mode = S_IRWXU|S_IRWXG|S_IRWXO;
+        gchar *dir, *ret = NULL;
 
         if (!path || !*path) {
-                path = g_get_home_dir();
-                nvds = nvd_dir;
+                const gchar *home = g_get_home_dir();
+                dir = g_build_path(G_DIR_SEPARATOR_S, home, nvd_dir, NULL);
+        } else {
+                dir = (gchar *) path;
         }
-        return g_build_path(G_DIR_SEPARATOR_S, path, nvds, nvd_file, NULL);
+
+        if (mkdir(dir, mode)) {
+                struct stat st = { .st_ino = 0, };
+
+                if (errno != EEXIST)
+                        goto end;
+
+                if (stat(dir, &st) || !S_ISDIR(st.st_mode))
+                        goto end;
+        }
+
+        ret = g_build_path(G_DIR_SEPARATOR_S, dir, nvd_file, NULL);
+end:
+        if (dir != path)
+                g_free(dir);
+        return ret;
 }
 
 static bool __update_required(const gchar *db_file, const gchar *update_fname)
@@ -154,19 +173,13 @@ bool update_db(bool quiet, const gchar *db_file)
                 goto end;
         }
 
-        db_exist = cve_file_exists(db_file);
-        if (!db_exist && !cve_file_exists(db_dir)) {
-                if (mkdir(db_dir, S_IRWXU|S_IRWXG|S_IRWXO)) {
-                        fprintf(stderr, "Unable to create required directory: %s\n", db_dir);
-                        goto end;
-                }
-        }
-
         u_handle = update_begin(u_fname);
         if (u_handle == -1) {
                 fprintf(stderr, "Can't create timestamp file %s\n", u_fname);
                 goto end;
         }
+
+        db_exist = cve_file_exists(db_file);
 
         cve_db = cve_db_new(db_file);
         if (!cve_db) {

--- a/src/update.c
+++ b/src/update.c
@@ -10,15 +10,19 @@
  */
 
 #define _GNU_SOURCE
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
 #include <stdint.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <utime.h>
 #include <glib.h>
 #include <gio/gio.h>
 #include <curl/curl.h>
-#include <sys/stat.h>
 
 #include "cve-check-tool.h"
 
@@ -34,6 +38,7 @@
 #define URI_PREFIX "http://static.nvd.nist.gov/feeds/xml/cve"
 #include "fetch.h"
 
+#define UPDATE_DB_FNAME_SUFFIX     "cve.update_db.ts"
 #define UPDATE_THRESHOLD 7200
 
 gchar *get_db_path(const gchar *path)
@@ -47,20 +52,64 @@ gchar *get_db_path(const gchar *path)
         return g_build_path(G_DIR_SEPARATOR_S, path, nvds, nvd_file, NULL);
 }
 
-static bool __update_required(const gchar *db_file)
+static bool __update_required(const gchar *db_file, const gchar *update_fname)
 {
         struct stat st;
         time_t t;
 
         memset(&st, 0, sizeof(st));
         if (stat(db_file, &st))
-                return true;
+                goto end;
+
+        if (!st.st_size)
+                goto unlink;
 
         t = time(NULL);
         if (difftime(t, st.st_mtime) >= UPDATE_THRESHOLD)
-                return true;
+                goto end;
+
+        memset(&st, 0, sizeof(st));
+        if (!stat(update_fname, &st))
+                goto unlink;
 
         return false;
+unlink:
+        /* Database partial load: unlink it to load again */
+        unlink(db_file);
+end:
+        return true;
+}
+
+int update_required(const gchar *db_file)
+{
+        autofree(char) *u_fname = NULL;
+
+        u_fname = get_db_dot_fname(db_file, UPDATE_DB_FNAME_SUFFIX);
+        if (!u_fname)
+                return -1;
+
+        return __update_required(db_file, u_fname);
+}
+
+#ifndef O_NOFOLLOW
+#define O_NOFOLLOW      0
+#endif
+
+static inline int update_begin(const char *update_fname)
+{
+        const int flags = O_RDONLY|O_CREAT|O_NONBLOCK|O_NOFOLLOW;
+        const mode_t mode = S_IRUSR|S_IWUSR;
+
+        return open(update_fname, flags, mode);
+}
+
+static inline void update_end(int fd, const char *update_fname, bool ok)
+{
+        if (fd != -1) {
+                close(fd);
+                if (ok)
+                        unlink(update_fname);
+        }
 }
 
 int update_required(const gchar *db_file)
@@ -74,10 +123,18 @@ bool update_db(bool quiet, const gchar *db_file)
         autofree(gchar) *db_dir = NULL;
         autofree(CveDB) *cve_db = NULL;
         autofree(GDateTime) *date = NULL;
+        autofree(char) *u_fname = NULL;
+        int u_handle = -1;
         int year;
         bool ret = false;
         bool db_exist = false;
         bool db_locked;
+
+        u_fname = get_db_dot_fname(db_file, UPDATE_DB_FNAME_SUFFIX);
+        if (!u_fname) {
+                fputs("update_db(): Out of memory\n", stderr);
+                goto end_no_lock;
+        }
 
         db_locked = cve_db_write_lock(LOCK_WAIT_SECS);
         if (!db_locked) {
@@ -86,7 +143,7 @@ bool update_db(bool quiet, const gchar *db_file)
         }
 
         /* Lock aquired, check if database is still needs update */
-        if (!update_required(db_file)) {
+        if (!__update_required(db_file, u_fname)) {
                 ret = true;
                 goto end;
         }
@@ -103,6 +160,12 @@ bool update_db(bool quiet, const gchar *db_file)
                         fprintf(stderr, "Unable to create required directory: %s\n", db_dir);
                         goto end;
                 }
+        }
+
+        u_handle = update_begin(u_fname);
+        if (u_handle == -1) {
+                fprintf(stderr, "Can't create timestamp file %s\n", u_fname);
+                goto end;
         }
 
         cve_db = cve_db_new(db_file);
@@ -162,9 +225,17 @@ bool update_db(bool quiet, const gchar *db_file)
                 }
         }
 
-        ret = true;
+        /* Make sure we always update access and modify time on
+         * database file, even if no new data loaded.
+         */
+        if (utime(db_file, NULL)) {
+                fprintf(stderr, "Unable to update file access and modify time\n");
+                goto end;
+        }
 
+        ret = true;
 end:
+        update_end(u_handle, u_fname, ret);
         cve_db_unlock();
 end_no_lock:
         return ret;

--- a/src/update.c
+++ b/src/update.c
@@ -159,14 +159,13 @@ static bool wait_file(gchar *path, int timeout)
 
 gchar *get_db_path(const gchar *path)
 {
-        const gchar *nvds_dir = "";
+        const gchar *nvds = "";
 
         if (!path || !*path) {
                 path = g_get_home_dir();
-                nvds_dir = "NVDS";
+                nvds = nvd_dir;
         }
-
-        return g_build_path(G_DIR_SEPARATOR_S, path, nvds_dir, "nvd.db", NULL);
+        return g_build_path(G_DIR_SEPARATOR_S, path, nvds, nvd_file, NULL);
 }
 
 static bool __update_required(const gchar *db_file, const gchar *lfile)

--- a/src/update.c
+++ b/src/update.c
@@ -37,41 +37,19 @@
 #define URI_PREFIX "http://static.nvd.nist.gov/feeds/xml/cve"
 #include "fetch.h"
 
-static bool do_unlock(void);
-
-static gchar *get_db_path(void)
-{
-        return g_build_path(G_DIR_SEPARATOR_S, g_get_home_dir(), "NVDS", "nvd.db", NULL);
-}
-
-gchar *get_lock_file(void)
-{
-        return g_build_path(G_DIR_SEPARATOR_S, g_get_home_dir(), "NVDS", "nvd.lock", NULL);
-}
-
 #define UPDATE_THRESHOLD 7200
 /* Wait at most 5 minutes for a parallel client */
 #define UPDATE_WAIT 300
 
+static bool do_unlock(void);
+
 static bool reg = false;
+static gchar *lock_file;
 static volatile int lock_fd = -1;
 
-bool update_required()
+static gchar *get_lock_file(const gchar *db_dir)
 {
-        time_t t;
-
-        autofree(gchar) *db = get_db_path();
-        struct stat st = {.st_ino = 0};
-        if (stat(db, &st) != 0) {
-                return true;
-        }
-
-        t = time(NULL);
-        if (difftime(t, st.st_mtime) >= UPDATE_THRESHOLD) {
-                return true;
-        }
-
-        return false;
+        return g_build_path(G_DIR_SEPARATOR_S, db_dir, "nvd.lock", NULL);
 }
 
 static void exit_unlock(void)
@@ -87,39 +65,51 @@ static void exit_unlock_sig(int sig)
         exit(sig);
 }
 
-static bool do_lock(gchar *path)
+static bool do_lock(const gchar *lfile)
 {
-        int fd = 0;
-        int res = 0;
-        struct flock lock = { 0 };
+        struct flock lock = { .l_type = F_WRLCK, };
+        int fd;
 
+        lfile = g_strdup(lfile);
+        if (!lfile)
+                goto err_out;
 
-        if ((fd = open(path, O_WRONLY|O_CREAT|O_NONBLOCK, S_IRUSR|S_IWUSR)) < 0) {
-                return false;
-        }
+        fd = open(lfile, O_WRONLY|O_CREAT|O_NONBLOCK, S_IRUSR|S_IWUSR);
+        if (fd == -1)
+                goto err_free;
 
-        lock.l_type = F_WRLCK;
-        if ((res = fcntl(fd, F_SETLK, &lock)) < 0) {
-                close(fd);
-                /* File existence is enough */
-                fprintf(stderr, "do_lock(): Failed to gain exclusive lock: %s\n", strerror(errno));
-                return false;
-        }
+        if (fcntl(fd, F_SETLK, &lock))
+                goto err_lock;
+
+        /* Lock aquired, store lock configuration before registering
+         * signal and atexit() handlers to let them unconfigure
+         * gracefully.
+         */
+        lock_file = lfile;
+        lock_fd = fd;
+
         if (!reg) {
                 reg = true;
                 signal(SIGINT, exit_unlock_sig);
                 atexit(exit_unlock);
         }
 
-        lock_fd = fd;
         return true;
+
+err_lock:
+        /* File existence is enough */
+        fprintf(stderr, "do_lock(): Failed to gain exclusive lock: %s\n", strerror(errno));
+        close(fd);
+err_free:
+        g_free(lfile);
+err_out:
+        return false;
 }
 
 
 static bool do_unlock()
 {
         struct flock lock = { 0 };
-        autofree(gchar) *lfile = NULL;
         bool ret = true;
 
         if (lock_fd < 0) {
@@ -137,17 +127,13 @@ static bool do_unlock()
         close(lock_fd);
         lock_fd = -1;
 
-        lfile = get_lock_file();
-        if (!lfile) {
-                fprintf(stderr, "do_unlock(): Out of memory\n");
+        if (unlink(lock_file) != 0) {
+                fprintf(stderr, "do_unlock(): Lockfile not removed, will cause issues.");
                 ret = false;
-        } else {
-                if (unlink(lfile) != 0) {
-                        fprintf(stderr, "do_unlock(): Lockfile not removed, will cause issues.");
-                        ret = false;
-                }
         }
 
+        g_free(lock_file);
+        lock_file = NULL;
 
         return ret;
 }
@@ -171,57 +157,102 @@ static bool wait_file(gchar *path, int timeout)
         }
 }
 
-bool update_db(bool quiet)
+gchar *get_db_path(const gchar *path)
 {
-        autofree(gchar) *db_path = NULL;
-        autofree(cve_string) *workdir = NULL;
+        const gchar *nvds_dir = "";
+
+        if (!path || !*path) {
+                path = g_get_home_dir();
+                nvds_dir = "NVDS";
+        }
+
+        return g_build_path(G_DIR_SEPARATOR_S, path, nvds_dir, "nvd.db", NULL);
+}
+
+static bool __update_required(const gchar *db_file, const gchar *lfile)
+{
+        struct stat st;
+        time_t t;
+
+        memset(&st, 0, sizeof(st));
+        if (stat(lfile, &st))
+                return true;
+
+        memset(&st, 0, sizeof(st));
+        if (stat(db_file, &st))
+                return true;
+
+        t = time(NULL);
+        if (difftime(t, st.st_mtime) >= UPDATE_THRESHOLD)
+                return true;
+
+        return false;
+}
+
+int update_required(const gchar *db_file)
+{
+        autofree(gchar) *db_dir = NULL;
+        autofree(gchar) *lfile = NULL;
+
+        db_dir = g_path_get_dirname(db_file);
+        if (!db_dir)
+                return -1;
+
+        lfile = get_lock_file(db_dir);
+        if (!lfile)
+                return -1;
+
+        return __update_required(db_file, lfile);
+}
+
+bool update_db(bool quiet, const gchar *db_file)
+{
+        const gchar *nvd_uri = URI_PREFIX;
+        autofree(gchar) *db_dir = NULL;
         autofree(CveDB) *cve_db = NULL;
-        __attribute__ ((unused)) struct stat st;
         autofree(GDateTime) *date = NULL;
-        autofree(gchar) *lock_file = NULL;
+        autofree(gchar) *lfile = NULL;
         int year;
         bool ret = false;
         bool db_exist = false;
 
-        db_path = get_db_path();
-        if (!db_path) {
+        db_dir = g_path_get_dirname(db_file);
+        if (!db_dir) {
                 fprintf(stderr, "update_db(): Out of memory\n");
                 goto end;
         }
 
-        lock_file = get_lock_file();
-        if (!lock_file) {
+        lfile = get_lock_file(db_dir);
+        if (!lfile) {
                 fprintf(stderr, "update_db(): Out of memory\n");
                 goto end;
         }
 
-        if (cve_file_exists(lock_file)) {
-                if (!wait_file(lock_file, UPDATE_WAIT)) {
+        if (cve_file_exists(lfile)) {
+                if (!wait_file(lfile, UPDATE_WAIT)) {
                         fprintf(stderr, "update_db(): Waited too long for parallel update\n");
                         goto end;
                 }
-                if (!update_required()) {
+                if (!__update_required(db_file, lfile)) {
                         return true;
                 }
         }
 
-        db_exist = cve_file_exists(db_path);
-
-        workdir = cve_string_dup_printf("%s/NVDS/", g_get_home_dir());
-        if (stat(workdir->str, &st) != 0) {
-                if (mkdir(workdir->str, 0777) != 0) {
-                        fprintf(stderr, "Unable to create required directory: %s\n", workdir->str);
+        db_exist = cve_file_exists(db_file);
+        if (!db_exist && !cve_file_exists(db_dir)) {
+                if (mkdir(db_dir, S_IRWXU|S_IRWXG|S_IRWXO)) {
+                        fprintf(stderr, "Unable to create required directory: %s\n", db_dir);
                         goto end;
                 }
         }
 
         /* Go and lock now. */
-        if (!do_lock(lock_file)) {
+        if (!do_lock(lfile)) {
                 fprintf(stderr, "update_db(): Cannot get lock file\n");
                 return false;
         }
 
-        cve_db = cve_db_new(db_path);
+        cve_db = cve_db_new(db_file);
         if (!cve_db) {
                 fprintf(stderr, "main(): DB initialisation issue\n");
                 goto end;
@@ -235,14 +266,18 @@ bool update_db(bool quiet)
                 autofree(gchar) *target = NULL;
                 FetchStatus st;
                 bool update = false;
+                gchar _nvdcve[sizeof("nvdcve-2.0-YYYY.xml.gz")];
+                const gchar *nvdcve;
 
                 if (i > year) {
-                        uri = g_strdup_printf("%s/nvdcve-2.0-Modified.xml.gz", URI_PREFIX);
-                        target = g_strdup_printf("%s/NVDS/nvdcve-2.0-Modified.xml.gz", g_get_home_dir());
+                        nvdcve = "nvdcve-2.0-Modified.xml.gz";
                 } else {
-                        uri = g_strdup_printf("%s/nvdcve-2.0-%d.xml.gz", URI_PREFIX, i);
-                        target = g_strdup_printf("%s/NVDS/nvdcve-2.0-%d.xml.gz", g_get_home_dir(), i);
+                        g_snprintf(_nvdcve, sizeof(_nvdcve), "nvdcve-2.0-%d.xml.gz", i);
+                        nvdcve = _nvdcve;
                 }
+
+                uri = g_strdup_printf("%s/%s", nvd_uri, nvdcve);
+                target = g_build_path(G_DIR_SEPARATOR_S, db_dir, nvdcve, NULL);
 
                 st = fetch_uri(uri, target, !quiet);
                 switch (st) {

--- a/src/update.c
+++ b/src/update.c
@@ -19,16 +19,13 @@
 #include <gio/gio.h>
 #include <curl/curl.h>
 #include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <errno.h>
-#include <signal.h>
 
 #include "cve-check-tool.h"
 
 #include "util.h"
 #include "config.h"
 #include "cve-string.h"
+#include "cve-db-lock.h"
 #include "core.h"
 
 #include "update.h"
@@ -38,124 +35,6 @@
 #include "fetch.h"
 
 #define UPDATE_THRESHOLD 7200
-/* Wait at most 5 minutes for a parallel client */
-#define UPDATE_WAIT 300
-
-static bool do_unlock(void);
-
-static bool reg = false;
-static gchar *lock_file;
-static volatile int lock_fd = -1;
-
-static gchar *get_lock_file(const gchar *db_dir)
-{
-        return g_build_path(G_DIR_SEPARATOR_S, db_dir, "nvd.lock", NULL);
-}
-
-static void exit_unlock(void)
-{
-        if (lock_fd > 0 && !do_unlock()) {
-                fprintf(stderr, "exit_unlock(): Failed to unlock cleanly\n");
-        }
-}
-
-static void exit_unlock_sig(int sig)
-{
-        exit_unlock();
-        exit(sig);
-}
-
-static bool do_lock(const gchar *lfile)
-{
-        struct flock lock = { .l_type = F_WRLCK, };
-        int fd;
-
-        lfile = g_strdup(lfile);
-        if (!lfile)
-                goto err_out;
-
-        fd = open(lfile, O_WRONLY|O_CREAT|O_NONBLOCK, S_IRUSR|S_IWUSR);
-        if (fd == -1)
-                goto err_free;
-
-        if (fcntl(fd, F_SETLK, &lock))
-                goto err_lock;
-
-        /* Lock aquired, store lock configuration before registering
-         * signal and atexit() handlers to let them unconfigure
-         * gracefully.
-         */
-        lock_file = lfile;
-        lock_fd = fd;
-
-        if (!reg) {
-                reg = true;
-                signal(SIGINT, exit_unlock_sig);
-                atexit(exit_unlock);
-        }
-
-        return true;
-
-err_lock:
-        /* File existence is enough */
-        fprintf(stderr, "do_lock(): Failed to gain exclusive lock: %s\n", strerror(errno));
-        close(fd);
-err_free:
-        g_free(lfile);
-err_out:
-        return false;
-}
-
-
-static bool do_unlock()
-{
-        struct flock lock = { 0 };
-        bool ret = true;
-
-        if (lock_fd < 0) {
-                return false;
-        }
-
-        /* Release it */
-        lock.l_type = F_UNLCK;
-        if (fcntl(lock_fd, F_SETLK, &lock) < 0) {
-                close(lock_fd);
-                fprintf(stderr, "do_unlock(): Unable to unlock file: %s\n", strerror(errno));
-                ret = false;
-        }
-
-        close(lock_fd);
-        lock_fd = -1;
-
-        if (unlink(lock_file) != 0) {
-                fprintf(stderr, "do_unlock(): Lockfile not removed, will cause issues.");
-                ret = false;
-        }
-
-        g_free(lock_file);
-        lock_file = NULL;
-
-        return ret;
-}
-
-static bool wait_file(gchar *path, int timeout)
-{
-        int elapsed = 0;
-
-        fprintf(stderr, "Waiting for another instance of cve-check-tool to finish updating\n");
-
-        while (true) {
-                if (!cve_file_exists(path)) {
-                        return true;
-                }
-                if (elapsed >= timeout) {
-                        return false;
-                }
-                /* Sure, it's fuzzy, but we don't need that kind of granularity */
-                sleep(1);
-                elapsed += 1;
-        }
-}
 
 gchar *get_db_path(const gchar *path)
 {
@@ -168,14 +47,10 @@ gchar *get_db_path(const gchar *path)
         return g_build_path(G_DIR_SEPARATOR_S, path, nvds, nvd_file, NULL);
 }
 
-static bool __update_required(const gchar *db_file, const gchar *lfile)
+static bool __update_required(const gchar *db_file)
 {
         struct stat st;
         time_t t;
-
-        memset(&st, 0, sizeof(st));
-        if (stat(lfile, &st))
-                return true;
 
         memset(&st, 0, sizeof(st));
         if (stat(db_file, &st))
@@ -190,18 +65,7 @@ static bool __update_required(const gchar *db_file, const gchar *lfile)
 
 int update_required(const gchar *db_file)
 {
-        autofree(gchar) *db_dir = NULL;
-        autofree(gchar) *lfile = NULL;
-
-        db_dir = g_path_get_dirname(db_file);
-        if (!db_dir)
-                return -1;
-
-        lfile = get_lock_file(db_dir);
-        if (!lfile)
-                return -1;
-
-        return __update_required(db_file, lfile);
+        return __update_required(db_file);
 }
 
 bool update_db(bool quiet, const gchar *db_file)
@@ -210,31 +74,27 @@ bool update_db(bool quiet, const gchar *db_file)
         autofree(gchar) *db_dir = NULL;
         autofree(CveDB) *cve_db = NULL;
         autofree(GDateTime) *date = NULL;
-        autofree(gchar) *lfile = NULL;
         int year;
         bool ret = false;
         bool db_exist = false;
+        bool db_locked;
+
+        db_locked = cve_db_write_lock(LOCK_WAIT_SECS);
+        if (!db_locked) {
+                fputs("Exiting...\n", stderr);
+                goto end_no_lock;
+        }
+
+        /* Lock aquired, check if database is still needs update */
+        if (!update_required(db_file)) {
+                ret = true;
+                goto end;
+        }
 
         db_dir = g_path_get_dirname(db_file);
         if (!db_dir) {
                 fprintf(stderr, "update_db(): Out of memory\n");
                 goto end;
-        }
-
-        lfile = get_lock_file(db_dir);
-        if (!lfile) {
-                fprintf(stderr, "update_db(): Out of memory\n");
-                goto end;
-        }
-
-        if (cve_file_exists(lfile)) {
-                if (!wait_file(lfile, UPDATE_WAIT)) {
-                        fprintf(stderr, "update_db(): Waited too long for parallel update\n");
-                        goto end;
-                }
-                if (!__update_required(db_file, lfile)) {
-                        return true;
-                }
         }
 
         db_exist = cve_file_exists(db_file);
@@ -243,12 +103,6 @@ bool update_db(bool quiet, const gchar *db_file)
                         fprintf(stderr, "Unable to create required directory: %s\n", db_dir);
                         goto end;
                 }
-        }
-
-        /* Go and lock now. */
-        if (!do_lock(lfile)) {
-                fprintf(stderr, "update_db(): Cannot get lock file\n");
-                return false;
         }
 
         cve_db = cve_db_new(db_file);
@@ -311,8 +165,8 @@ bool update_db(bool quiet, const gchar *db_file)
         ret = true;
 
 end:
-        do_unlock();
-
+        cve_db_unlock();
+end_no_lock:
         return ret;
 }
 

--- a/src/update.c
+++ b/src/update.c
@@ -12,6 +12,7 @@
 #define _GNU_SOURCE
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/mman.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -41,6 +42,15 @@
 
 #define UPDATE_DB_FNAME_SUFFIX     "cve.update_db.ts"
 #define UPDATE_THRESHOLD 7200
+
+typedef struct {
+        void *mmap;
+        off_t length;
+        int fd;
+} ndi_t;
+
+static void nvdcve_data_fini(ndi_t *ndi);
+DEF_AUTOFREE(ndi_t, nvdcve_data_fini)
 
 gchar *get_db_path(const gchar *path)
 {
@@ -98,7 +108,137 @@ static gchar *nvdcve_get_pname(int year, const gchar *db_dir, const gchar *fext)
         return __nvdcve_get_pname(year, db_dir, fext, &fname);
 }
 
-static bool __update_required(const gchar *db_file, const gchar *update_fname)
+static inline FILE *nvdcve_meta_open(const char *f_name)
+{
+        return fopen(f_name, "r");
+}
+
+static inline void nvdcve_meta_close(FILE *f)
+{
+        fclose(f);
+}
+
+static char *nvdcve_meta_get_val(FILE *f, const char *field)
+{
+        do {
+                char field_name[256], field_value[256];
+                int ret;
+
+                ret = fscanf(f, " %255[^: \f\n\r\t\v] :%255s",
+                             field_name, field_value);
+                if (ret != 2) {
+                        if (ret != EOF)
+                                continue;
+                        if (ferror(f)) {
+                                if (errno == EINTR || errno == EAGAIN) {
+                                        clearerr(f);
+                                        continue;
+                                }
+                        }
+                        return NULL;
+                }
+                if (!strcmp(field_name, field))
+                        return strdup(field_value);
+        } while (1);
+}
+
+static ndi_t *nvdcve_data_init_read(const gchar *f_path)
+{
+        ndi_t *ndi;
+        struct stat sb;
+
+        ndi = calloc(1, sizeof(*ndi));
+        if (!ndi)
+                goto err_fini;
+
+        ndi->fd = open(f_path, O_RDONLY);
+        if (ndi->fd == -1)
+                goto err_fini;
+
+        memset(&sb, 0, sizeof(sb));
+        if (fstat(ndi->fd, &sb))
+                goto err_fini;
+        ndi->length = sb.st_size;
+
+        ndi->mmap = mmap(NULL, ndi->length, PROT_READ, MAP_PRIVATE, ndi->fd, 0);
+        if (!ndi->mmap)
+                goto err_fini;
+
+        return ndi;
+
+err_fini:
+        nvdcve_data_fini(ndi);
+        return NULL;
+}
+
+static void nvdcve_data_fini(ndi_t *ndi)
+{
+        if (ndi) {
+                if (ndi->mmap)
+                        munmap(ndi->mmap, ndi->length);
+                if (ndi->fd != -1)
+                        close(ndi->fd);
+                free(ndi);
+        }
+}
+
+static void nvdcve_unlink(const gchar *nvdcve_meta, const gchar *nvdcve_data)
+{
+        autofree(gchar) *nvdcve_data_gz = NULL;
+
+        unlink(nvdcve_meta);
+        unlink(nvdcve_data);
+
+        nvdcve_data_gz = g_build_path("", nvdcve_data, ".gz", NULL);
+        if (nvdcve_data_gz)
+                unlink(nvdcve_data_gz);
+}
+
+static bool nvdcve_data_ok(int year, const gchar *db_dir)
+{
+        autofree(ndi_t) *ndi = NULL;
+        autofree(gchar) *nvdcve_meta = NULL;
+        autofree(gchar) *nvdcve_data = NULL;
+        autofree(char) *csum_reference = NULL;
+        autofree(gchar) *csum_result = NULL;
+        FILE *nvdcve_meta_file;
+
+        nvdcve_meta = nvdcve_get_pname(year, db_dir, "meta");
+        if (!nvdcve_meta)
+                return false;
+
+        nvdcve_meta_file = nvdcve_meta_open(nvdcve_meta);
+        if (!nvdcve_meta_file)
+                return false;
+
+        csum_reference = nvdcve_meta_get_val(nvdcve_meta_file, "sha256");
+
+        nvdcve_meta_close(nvdcve_meta_file);
+
+        if (!csum_reference)
+                return false;
+
+        nvdcve_data = nvdcve_get_pname(year, db_dir, "xml");
+        if (!nvdcve_data)
+                return false;
+
+        ndi = nvdcve_data_init_read(nvdcve_data);
+        if (!ndi)
+                return false;
+
+        csum_result = g_compute_checksum_for_data(G_CHECKSUM_SHA256,
+                                                  ndi->mmap, ndi->length);
+        if (!csum_result)
+                return false;
+
+        if (strcmp(csum_result, csum_reference))
+                return false;
+
+        return true;
+}
+
+static bool __update_required(const gchar *db_file, const gchar *db_dir,
+                              const gchar *update_fname)
 {
         struct stat st;
         time_t t;
@@ -128,13 +268,18 @@ end:
 
 int update_required(const gchar *db_file)
 {
+        autofree(gchar) *db_dir = NULL;
         autofree(char) *u_fname = NULL;
 
         u_fname = get_db_dot_fname(db_file, UPDATE_DB_FNAME_SUFFIX);
         if (!u_fname)
                 return -1;
 
-        return __update_required(db_file, u_fname);
+        db_dir = g_path_get_dirname(db_file);
+        if (!db_dir)
+                return -1;
+
+        return __update_required(db_file, db_dir, u_fname);
 }
 
 #ifndef O_NOFOLLOW
@@ -160,48 +305,91 @@ static int do_fetch_update(int year, const gchar *db_dir, CveDB *cve_db,
                            bool db_exist, bool verbose)
 {
         const gchar *nvd_uri = URI_PREFIX;
-        autofree(gchar) *uri = NULL;
-        autofree(gchar) *target = NULL;
+        autofree(gchar) *uri_meta = NULL;
+        autofree(gchar) *uri_data = NULL;
+        autofree(gchar) *nvdcve_meta = NULL;
+        autofree(gchar) *nvdcve_data = NULL;
         autofree(gchar) *nvd_xml_gz = NULL;
+        autofree(gchar) *nvd_meta = NULL;
         FetchStatus st;
-        bool update = false;
+        bool update, load, refetched = false;
 
-        target = __nvdcve_get_pname(year, db_dir, "xml.gz", &nvd_xml_gz);
-        if (!target)
+        /* Prepare NVD META file/uri pathes */
+        nvdcve_meta = __nvdcve_get_pname(year, db_dir, "meta", &nvd_meta);
+        if (!nvdcve_meta)
                 return ENOMEM;
 
-        uri = g_strdup_printf("%s/%s", nvd_uri, nvd_xml_gz);
-        if (!uri)
+        uri_meta = g_strdup_printf("%s/%s", nvd_uri, nvd_meta);
+        if (!uri_meta)
                 return ENOMEM;
 
-        st = fetch_uri(uri, target, verbose);
+        /* Prepare NVD XML file/uri pathes */
+        nvdcve_data = __nvdcve_get_pname(year, db_dir, "xml.gz", &nvd_xml_gz);
+        if (!nvdcve_data)
+                return ENOMEM;
+
+        uri_data = g_strdup_printf("%s/%s", nvd_uri, nvd_xml_gz);
+        if (!uri_data)
+                return ENOMEM;
+
+refetch:
+        if (refetched)
+                nvdcve_unlink(nvdcve_meta, nvdcve_data);
+
+        /* Fetch NVD META file */
+        st = fetch_uri(uri_meta, nvdcve_meta, verbose);
+        if (st == FETCH_STATUS_FAIL) {
+                fprintf(stderr, "Failed to fetch %s\n", uri_meta);
+                return -1;
+        }
+
+        /* Fetch NVD XML file */
+        st = fetch_uri(uri_data, nvdcve_data, verbose);
         switch (st) {
         case FETCH_STATUS_FAIL:
-                fprintf(stderr, "Failed to fetch %s\n", uri);
+                fprintf(stderr, "Failed to fetch %s\n", uri_data);
                 return -1;
         case FETCH_STATUS_UPDATE:
-                update = true;
+                update = load = true;
                 break;
         default:
-                if (verbose) {
-                        fprintf(stderr, "Skipping: %s\n", nvd_xml_gz);
-                }
+                update = !nvdcve_data_ok(year, db_dir);
+                load = !db_exist;
                 break;
         }
 
-        if (update || !db_exist) {
-                /* Only load on updates */
-                if (!gunzip_file(target)) {
-                        fprintf(stderr, "Unable to extract %s\n", target);
+        if (update) {
+                if (!gunzip_file(nvdcve_data)) {
+                        if (!refetched) {
+                                refetched = true;
+                                goto refetch;
+                        }
+                        fprintf(stderr, "Unable to extract %s\n", nvdcve_data);
                         return -1;
                 }
-                if (!cve_db_load(cve_db, target)) {
-                        fprintf(stderr, "\nUnable to find: %s\n", target);
+                if (!nvdcve_data_ok(year, db_dir)) {
+                        if (!refetched) {
+                                refetched = true;
+                                goto refetch;
+                        }
+                        fprintf(stderr, "Fetched data %s is not consistent\n", nvdcve_data);
                         return -1;
                 }
-                if (verbose) {
-                        fprintf(stderr, "Loaded: %s\n", nvd_xml_gz);
+        }
+
+        if (load) {
+                if (!cve_db_load(cve_db, nvdcve_data)) {
+                        fprintf(stderr, "\nUnable to load: %s\n", nvdcve_data);
+                        return -1;
                 }
+        }
+
+        if (verbose) {
+                static const char data_report_msg[][sizeof("Skipp")] = {
+                        [false] = "Skipp",
+                        [true]  = "Load",
+                };
+                fprintf(stderr, "%sed: %s\n", data_report_msg[load], nvd_xml_gz);
         }
 
         return 0;
@@ -234,7 +422,7 @@ bool update_db(bool quiet, const gchar *db_file)
         }
 
         /* Lock aquired, check if database is still needs update */
-        if (!__update_required(db_file, u_fname)) {
+        if (!__update_required(db_file, db_dir, u_fname)) {
                 ret = true;
                 goto end;
         }

--- a/src/update.c
+++ b/src/update.c
@@ -156,14 +156,59 @@ static inline void update_end(int fd, const char *update_fname, bool ok)
                 unlink(update_fname);
 }
 
-int update_required(const gchar *db_file)
+static int do_fetch_update(int year, const gchar *db_dir, CveDB *cve_db,
+                           bool db_exist, bool verbose)
 {
-        return __update_required(db_file);
+        const gchar *nvd_uri = URI_PREFIX;
+        autofree(gchar) *uri = NULL;
+        autofree(gchar) *target = NULL;
+        autofree(gchar) *nvd_xml_gz = NULL;
+        FetchStatus st;
+        bool update = false;
+
+        target = __nvdcve_get_pname(year, db_dir, "xml.gz", &nvd_xml_gz);
+        if (!target)
+                return ENOMEM;
+
+        uri = g_strdup_printf("%s/%s", nvd_uri, nvd_xml_gz);
+        if (!uri)
+                return ENOMEM;
+
+        st = fetch_uri(uri, target, verbose);
+        switch (st) {
+        case FETCH_STATUS_FAIL:
+                fprintf(stderr, "Failed to fetch %s\n", uri);
+                return -1;
+        case FETCH_STATUS_UPDATE:
+                update = true;
+                break;
+        default:
+                if (verbose) {
+                        fprintf(stderr, "Skipping: %s\n", nvd_xml_gz);
+                }
+                break;
+        }
+
+        if (update || !db_exist) {
+                /* Only load on updates */
+                if (!gunzip_file(target)) {
+                        fprintf(stderr, "Unable to extract %s\n", target);
+                        return -1;
+                }
+                if (!cve_db_load(cve_db, target)) {
+                        fprintf(stderr, "\nUnable to find: %s\n", target);
+                        return -1;
+                }
+                if (verbose) {
+                        fprintf(stderr, "Loaded: %s\n", nvd_xml_gz);
+                }
+        }
+
+        return 0;
 }
 
 bool update_db(bool quiet, const gchar *db_file)
 {
-        const gchar *nvd_uri = URI_PREFIX;
         autofree(gchar) *db_dir = NULL;
         autofree(CveDB) *cve_db = NULL;
         autofree(GDateTime) *date = NULL;
@@ -212,49 +257,14 @@ bool update_db(bool quiet, const gchar *db_file)
         year = g_date_time_get_year(date);
 
         for (int i = YEAR_START; i <= year+1; i++) {
-                autofree(gchar) *uri = NULL;
-                autofree(gchar) *target = NULL;
-                autofree(gchar) *nvd_xml_gz = NULL;
-                FetchStatus st;
-                bool update = false;
+                int y = i > year ? -1 : i;
+                int rc;
 
-                target = __nvdcve_get_pname(i > year ? -1 : i, db_dir,
-                                            "xml.gz", &nvd_xml_gz);
-                if (!target)
+                rc = do_fetch_update(y, db_dir, cve_db, db_exist, !quiet);
+                if (rc == ENOMEM)
                         goto oom;
-
-                uri = g_strdup_printf("%s/%s", nvd_uri, nvd_xml_gz);
-                if (!uri)
-                        goto oom;
-
-                st = fetch_uri(uri, target, !quiet);
-                switch (st) {
-                        case FETCH_STATUS_FAIL:
-                                fprintf(stderr, "Failed to fetch %s\n", uri);
-                                goto end;
-                        case FETCH_STATUS_UPDATE:
-                                update = true;
-                                break;
-                        default:
-                                if (!quiet) {
-                                        fprintf(stderr, "Skipping: %s\n", nvd_xml_gz);
-                                }
-                                break;
-                }
-                if (update || !db_exist) {
-                        /* Only load on updates */
-                        if (!gunzip_file(target)) {
-                                fprintf(stderr, "Unable to extract %s\n", target);
-                                goto end;
-                        }
-                        if (!cve_db_load(cve_db, target)) {
-                                fprintf(stderr, "\nUnable to find: %s\n", target);
-                                goto end;
-                        }
-                        if (!quiet) {
-                                fprintf(stderr, "Loaded: %s\n", nvd_xml_gz);
-                        }
-                }
+                if (rc)
+                        goto end;
         }
 
         /* Make sure we always update access and modify time on

--- a/src/update.h
+++ b/src/update.h
@@ -14,11 +14,11 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+gchar *get_db_path(const gchar *path);
 
-bool update_required(void);
-gchar *get_lock_file(void);
+int update_required(const gchar *db_file);
 
-bool update_db(bool quiet);
+bool update_db(bool quiet, const gchar *db_file);
 
 
 /*


### PR DESCRIPTION
Hi. With this patch series I would like to introduce/extend following functionality of the cve-check-tool:

Most of the effort applied to improve database and check results consistency in multi user/instance environments. One of good example of such environment is Image Security Framework (ISAFW) used with meta-security-isafw custom layer in YOCTO project.

All patches tested before submission and seems to compile & work correctly in my test cases addressing all issues I found while working for ISAFW improvements.

* Support for specifying database location in filesystem via command line option (commits f432f9d and 652ae0a)
* Changes to the output plugin logic: now all plugins (currently HTML, CSV and CLI) use stdout to generate reports. This eases report processing. Error messages now sent to the stderr to not interfere with report data. (commits 9cfb9be, a7a5b59, eefa193, cea2b64)
* Small code clean up in prepare for the upcoming changes (commit cea2b64)
* Database locking extended to serialize all access to the database. Before this patch only parallel updates protected from each other, while readers still could access data in the middle of update process. Patch introduces full shared vs exclusive POSIX advisory locking, where exclusive locking
used only for database update process, and shared locking used by multiple instances for database checks (commit 568ac0f).
* Introduce marker file in the database directory to correctly handling database partial updates (commits 567126f, 0f4bb46).
* Fixes to ensure database directory exists before working with locks (commit fcbef7f).
* Small series of changes to consolidate out-of-memory (oom) error handling in update_db(). While
it uses goto statement it is pretty clean to read and I think makes code readable a bit. Statement is used in the similar way as with Linux kernel error path handling, so I think it is ok here (commit 705a2be).
* Check NVD XML files integrity before processing. Among with XML DATA files NVD provides META files. These files are colon separated list of *key*:*value*. One of the *key* provides sha256 digest of the uncompressed XML data file, so we can compute sha256 digest on fetched/unpacked data and compare it to the reference value from the "sha256" *key* in META file.
These checksumming does not ensure source authenticity (e.g. like digital signatures), but it is
used to catch partial downloads. Also fetch/unpack/update mechanism was changed to be more robust and retry at least once (commits 1b1bee3, 5c6cf61, b6ccdd8).
