### PR TITLE
Next2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,7 @@ m4_define([curl_required_version], [7.29.0])
 m4_define([gobject_required_version], [2.0])
 m4_define([check_required_version], [0.9])
 m4_define([json_required_version], [0.16.0])
+m4_define([openssl_required_version],[1.0.0])
 # TODO: Set minimum sqlite
 
 PKG_CHECK_MODULES(CVE_CHECK_TOOL,
@@ -26,7 +27,8 @@ PKG_CHECK_MODULES(CVE_CHECK_TOOL,
                   libcurl >= curl_required_version,
                   json-glib-1.0 >= json_required_version,
                   gobject-2.0 >= gobject_required_version,
-                  sqlite3
+                  sqlite3,
+                  openssl >= openssl_required_version
                   ])
 
 PKG_CHECK_MODULES(MODULE_COMMON,

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,6 +21,8 @@ libcve_la_SOURCES = \
 	library/cve-string.c \
 	library/hashmap.h \
 	library/hashmap.c \
+	library/cve-db-lock.h \
+	library/cve-db-lock.c \
 	library/fetch.c \
 	library/fetch.h \
 	library/template.c \

--- a/src/core.c
+++ b/src/core.c
@@ -32,8 +32,8 @@
 
 #include <sqlite3.h>
 
-#define YEAR_START 2002
-#define URI_PREFIX "http://static.nvd.nist.gov/feeds/xml/cve"
+const char nvd_file[] = "nvd.db";
+const char nvd_dir[] = "NVDS";
 
 struct CveDB {
         /** XML traversal state */

--- a/src/core.h
+++ b/src/core.h
@@ -13,6 +13,9 @@
 #include <libxml/xmlreader.h>
 #include "common.h"
 
+extern const char nvd_file[];        /* nvd.db */
+extern const char nvd_dir[];         /* NVDS */
+
 /**
  * A CVE Database, using the National Vulnerability Database as its source
  */

--- a/src/library/cve-db-lock.c
+++ b/src/library/cve-db-lock.c
@@ -1,0 +1,193 @@
+/*
+ * cve-check-tool.c
+ *
+ * Copyright (C) 2015-2016 Sergey Popovich <popovich_sergei@mail.ua>.
+ *
+ * cve-check-tool is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#define _GNU_SOURCE
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <assert.h>
+
+#include "core.h"
+#include "util.h"
+#include "cve-string.h"
+#include "cve-db-lock.h"
+
+static const short int locktype2l_type[LT_MAX + 1] = {
+        [LT_READ]       = F_RDLCK,
+        [LT_WRITE]      = F_WRLCK,
+};
+
+static const char locktype2string[LT_MAX + 1][sizeof("write")] = {
+        [LT_READ]       = "read",
+        [LT_WRITE]      = "write",
+};
+
+static int db_lock_fd = -1;
+static cve_string *db_lock_fname;
+
+#ifndef O_NOFOLLOW
+#define O_NOFOLLOW      0
+#endif
+
+bool cve_db_lock_init(const char *db_path)
+{
+        const int flags = O_RDWR|O_CREAT|O_NONBLOCK|O_NOFOLLOW;
+        const mode_t mode = S_IRUSR|S_IWUSR;
+        autofree(char) *path = NULL;
+        const char *dir;
+        char *file;
+
+        assert(db_lock_fd < 0);
+        assert(db_lock_fname == NULL);
+        assert(db_path != NULL);
+
+        path = strdup(db_path);
+        if (!path) {
+                return false;
+        }
+
+        file = strrchr(path, '/');
+        if (file) {
+                *file++ = '\0';
+                if (!*file) {
+                        file = (char *) nvd_file;
+                }
+                dir = *path ? path : ".";
+        } else {
+                file = path;
+                dir = ".";
+        }
+
+        db_lock_fname = cve_string_dup_printf("%s/.%s.cve.lock", dir, file);
+        if (!db_lock_fname) {
+                return false;
+        }
+
+        db_lock_fd = open(db_lock_fname->str, flags, mode);
+        if (db_lock_fd < 0) {
+                cve_string_free(db_lock_fname);
+                db_lock_fname = NULL;
+                return false;
+        }
+
+        return true;
+}
+
+void cve_db_lock_fini(void)
+{
+        assert(db_lock_fd >= 0);
+        assert(db_lock_fname != NULL);
+
+        close(db_lock_fd);
+        db_lock_fd = -1;
+
+        unlink(db_lock_fname->str);
+        cve_string_free(db_lock_fname);
+        db_lock_fname = NULL;
+}
+
+bool cve_db_lock(locktype lt, int wait)
+{
+        const char *lt_str;
+        unsigned int waited;
+
+        assert(lt < LT_MAX + 1);
+        assert(db_lock_fd >= 0);
+
+        lt_str = locktype2string[lt];
+
+        if (wait < 0) {
+                waited = wait = 2;
+        } else {
+                waited = 0;
+        }
+
+        do {
+                struct flock fl = {
+                        .l_type         = locktype2l_type[lt],
+                        .l_whence       = SEEK_SET,
+                };
+                int ret;
+
+                ret = fcntl(db_lock_fd, F_SETLK, &fl);
+                if (!ret) {
+                        return true;
+                }
+                if (errno != EAGAIN && errno != EACCES) {
+                        fprintf(stderr,
+                                "Error acquiring database lock: %s\n",
+                                strerror(errno));
+                        break;
+                }
+
+                if (waited % 2) {
+                        goto sleep;
+                }
+                fputs("Another app holds the lock on database", stderr);
+                if (wait) {
+                        int remaining = wait - waited;
+                        if (remaining <= 0) {
+                                fprintf(stderr,
+                                        "; %s lock is not acquired\n", lt_str);
+                                break;
+                        }
+                        fprintf(stderr,
+                                "; acquiring %s lock within %ds ...",
+                                lt_str, remaining);
+                } else {
+                        fputs("; waiting indefinitely", stderr);
+                }
+                fputc('\n', stderr);
+sleep:
+                sleep(1);
+                waited++;
+                if (wait && waited >= (unsigned int) wait) {
+                        /* last round: make it even */
+                        waited = (wait + 1) & ~1;
+                }
+        } while (1);
+
+        return false;
+}
+
+void cve_db_unlock(void)
+{
+        struct flock fl = {
+                .l_type         = F_UNLCK,
+                .l_whence       = SEEK_SET,
+        };
+        int ret;
+
+        ret = fcntl(db_lock_fd, F_SETLK, &fl);
+
+        assert(ret == 0);
+}
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/src/library/cve-db-lock.c
+++ b/src/library/cve-db-lock.c
@@ -50,31 +50,12 @@ bool cve_db_lock_init(const char *db_path)
         const int flags = O_RDWR|O_CREAT|O_NONBLOCK|O_NOFOLLOW;
         const mode_t mode = S_IRUSR|S_IWUSR;
         autofree(char) *path = NULL;
-        const char *dir;
-        char *file;
 
         assert(db_lock_fd < 0);
         assert(db_lock_fname == NULL);
         assert(db_path != NULL);
 
-        path = strdup(db_path);
-        if (!path) {
-                return false;
-        }
-
-        file = strrchr(path, '/');
-        if (file) {
-                *file++ = '\0';
-                if (!*file) {
-                        file = (char *) nvd_file;
-                }
-                dir = *path ? path : ".";
-        } else {
-                file = path;
-                dir = ".";
-        }
-
-        db_lock_fname = cve_string_dup_printf("%s/.%s.cve.lock", dir, file);
+        db_lock_fname = make_db_dot_fname(db_path, "cve.lock");
         if (!db_lock_fname) {
                 return false;
         }

--- a/src/library/cve-db-lock.h
+++ b/src/library/cve-db-lock.h
@@ -1,0 +1,100 @@
+/*
+ * cve-check-tool.h
+ *
+ * Copyright (C) 2015-2016 Sergey Popovich <popovich_sergei@mail.ua>.
+ *
+ * cve-check-tool is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <stdbool.h>
+
+/**
+ * Enumerate to represent possible locking types to imply on the
+ * database file
+ */
+typedef enum {
+        LT_READ         = 0,            /**<Shared lock type */
+        LT_WRITE,                       /**<Exclusive lock type */
+        __LT_MAX
+} locktype;
+
+#define LT_MAX          (__LT_MAX - 1)
+
+enum {
+        LOCK_WAIT_SECS  = 5 * 60,       /**<Wait for lock to aquire 5 minutes */
+};
+
+/**
+ * Initialize lock on the database by opening it's file and saving
+ * descriptor for later use by other locking functions
+ *
+ * @note If database file does not exists it will be created
+ *
+ * @param db_file Database file to operate on
+ * @return True if database file opened successfuly and false overwise
+ */
+bool cve_db_lock_init(const char *db_file);
+
+/**
+ * Finalizes lock usage on database file by closing corresponding
+ * file descriptor
+ *
+ * @note Any locking, if applied to the file descriptor will be released
+ */
+void cve_db_lock_fini(void);
+
+/**
+ * Try to aquire lock of the given type on the previously initialized
+ * database file descriptor within given timeout
+ *
+ * @param lt Lock type to aquire as specified by the enum locktype
+ * @param wait Number of seconds to wait for lock before giving up
+ * If specified as < 0 then return immediately, 0 means wait
+ * indefinitely to aquire lock.
+ */
+bool cve_db_lock(locktype lt, int wait);
+
+/**
+ * Helper routine to aquire shared (read) lock within given timeout
+ *
+ * @note Calls cve_db_lock() with LT_READ to perform real work
+ *
+ * @param wait Number of seconds to wait for lock before giving up
+ */
+static inline bool cve_db_read_lock(int wait)
+{
+        return cve_db_lock(LT_READ, wait);
+}
+
+/**
+ * Helper routine to aquire exclusive (write) lock within given timeout
+ *
+ * @note Calls cve_db_lock() with LT_WRITE to perform real work
+ *
+ * @param wait Number of seconds to wait for lock before giving up
+ */
+static inline bool cve_db_write_lock(int wait)
+{
+        return cve_db_lock(LT_WRITE, wait);
+}
+
+/**
+ * Releases previously aquired lock from database file
+ */
+void cve_db_unlock(void);
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/src/library/hashmap.c
+++ b/src/library/hashmap.c
@@ -59,7 +59,6 @@ typedef struct _CveHashmapIter {
         void *item;              /**<Current item in this iteration */
 } _CveHashmapIter;
 
-static void *cve_hashmap_remove_internal(CveHashmap *self, const void *key, bool remove);
 static void cve_hashmap_update_next_size(CveHashmap *self);
 static bool cve_hashmap_resize(CveHashmap *self);
 
@@ -228,10 +227,10 @@ void *cve_hashmap_get(CveHashmap *self, const void *key)
         return NULL;
 }
 
-static void *cve_hashmap_remove_internal(CveHashmap *self, const void *key, bool remove)
+static bool cve_hashmap_remove_internal(CveHashmap *self, const void *key, bool remove)
 {
         if (!self) {
-                return NULL;
+                return false;
         }
         CveHashmapEntry *row = cve_hashmap_get_entry(self, key);
 

--- a/src/library/template.c
+++ b/src/library/template.c
@@ -285,25 +285,19 @@ static inline bool within_list(TemplateContext *self)
         return false;
 }
 
-char *template_context_process_line(TemplateContext *self, const char *original, bool skip)
+cve_string *template_context_process_line(TemplateContext *self, const char *original, bool skip)
 {
         char *c = NULL, *s = NULL;
         int offset = 0;
         TemplateContext *ctx = self;
+        cve_string *input;
 
-        if (!ctx || !ctx->values) {
+        input = cve_string_dup(original);
+
+        if (!input || !ctx || !ctx->values) {
                 /* Always return allocated string for consistency */
-                return strdup((char*) original);
+                return input;
         }
-        if (!original) {
-                return NULL;
-        }
-
-        cve_string *input = cve_string_dup(original);
-        if (!input) {
-                return NULL;
-        }
-
 
         while ((c = memchr(input->str+offset, '{', input->len-offset))) {
                 autofree(cve_string) *newstr = NULL;
@@ -372,30 +366,31 @@ char *template_context_process_line(TemplateContext *self, const char *original,
                         gchar *sect = newstr->str+1;
                         if (ctx->name && g_str_equal(sect, ctx->name)) {
                                 if (ctx->block) {
-                                        autofree(cve_string) *contents = cve_string_dup(ctx->block->str);
-                                        cve_string_free(ctx->block);
+                                        autofree(cve_string) *contents = ctx->block;
+                                        cve_string *complete;
                                         ctx->block = NULL;
                                         /* Search parent for the value in question */
                                         TCValue *val = find_context_value(ctx->parent, ctx->name);
                                         if (val && val->type == TC_VALUE_TYPE_LIST) {
                                                 GList *root = val->value, *child = NULL;
                                                 for (child = root; child; child = child->next) {
-                                                        autofree(gchar) *complete = NULL;
                                                         TemplateContext *cctx = child->data;
                                                         complete = template_context_process_line(cctx, contents->str, true);
                                                         if (!ctx->parent->block) {
-                                                                ctx->parent->block = cve_string_dup(complete);
+                                                                ctx->parent->block = complete;
                                                         } else {
-                                                                cve_string_cat(ctx->parent->block, complete);
+                                                                cve_string_cat(ctx->parent->block, complete->str);
+                                                                cve_string_free(complete);
                                                         }
                                                 }
                                         } else {
                                                 /* Normal textual content */
-                                                autofree(gchar) *complete = template_context_process_line(ctx, contents->str, true);
+                                                complete = template_context_process_line(ctx, contents->str, true);
                                                 if (!ctx->parent->block) {
-                                                        ctx->parent->block = cve_string_dup(complete);
+                                                        ctx->parent->block = complete;
                                                 } else {
-                                                        cve_string_cat(ctx->parent->block, complete);
+                                                        cve_string_cat(ctx->parent->block, complete->str);
+                                                        cve_string_free(complete);
                                                 }
                                         }
                                 }
@@ -473,37 +468,40 @@ bail:
                         cve_string_cat(ctx->block, input->str+offset);
                 }
         }
-        if (input) {
-                cve_string_free(input);
-        }
+
+        cve_string_free(input);
+
         if (ctx->block) {
-                char *ret = g_strdup(ctx->block->str);
-                cve_string_free(ctx->block);
+                input = ctx->block;
                 ctx->block = NULL;
-                return ret;
+        } else {
+                input = NULL;
         }
 
-        return NULL;
+        return input;
 }
 
-char *template_string(const char *original, GHashTable *keys)
+cve_string *template_string(const char *original, GHashTable *keys)
 {
         autofree(TemplateContext) *context = NULL;
         GHashTableIter iter;
         gchar *key = NULL, *value = NULL;
 
+        if (!original) {
+                return NULL;
+        }
+
         if (!keys) {
-                return g_strdup(original);
+                return cve_string_dup(original);
         }
 
         context = template_context_new();
 
-        if (keys) {
-                g_hash_table_iter_init(&iter, keys);
-                while (g_hash_table_iter_next(&iter, (void**)&key, (void**)&value)) {
-                        template_context_add_string(context, key, value);
-                }
+        g_hash_table_iter_init(&iter, keys);
+        while (g_hash_table_iter_next(&iter, (void**)&key, (void**)&value)) {
+                template_context_add_string(context, key, value);
         }
+
         return template_context_process_line(context, original, false);
 }
 

--- a/src/library/template.h
+++ b/src/library/template.h
@@ -29,7 +29,7 @@ typedef struct TemplateContext TemplateContext;
  * @param keys A string->string kv GHashTable
  * @return A newly allocated string with all replacements performed
  */
-char *template_string(const char *original, GHashTable *keys);
+cve_string *template_string(const char *original, GHashTable *keys);
 
 /**
  * Replace all {{style}} variables in a string with the string values
@@ -45,7 +45,7 @@ char *template_string(const char *original, GHashTable *keys);
  * @param skip Skip section expansion/rendering, default should be false.
  * @return A newly allocated string with all replacements performed
  */
-char *template_context_process_line(TemplateContext *context, const char *original, bool skip);
+cve_string *template_context_process_line(TemplateContext *context, const char *original, bool skip);
 
 /**
  * Create a new TemplateContext

--- a/src/library/util.c
+++ b/src/library/util.c
@@ -25,9 +25,6 @@
 #include "cve-check-tool.h"
 
 
-#define streq(x,y) strcmp(x,y) == 0
-
-DEF_AUTOFREE(char, free)
 
 bool find_sources(const char *path, package_match_func match, bool recurse, cve_add_callback cb)
 {

--- a/src/library/util.c
+++ b/src/library/util.c
@@ -23,6 +23,7 @@
 
 #include "util.h"
 #include "cve-check-tool.h"
+#include "cve-string.h"
 
 
 
@@ -249,6 +250,32 @@ char *cve_get_file_parent(const char *p)
                 return NULL;
         }
         return dirname(r);
+}
+
+cve_string *make_db_dot_fname(const char *db_path, const char *suffix)
+{
+        autofree(char) *path = NULL;
+        const char *dir;
+        char *file;
+
+        path = strdup(db_path);
+        if (!path) {
+                return NULL;
+        }
+
+        file = strrchr(path, '/');
+        if (file) {
+                *file++ = '\0';
+                if (!*file) {
+                        file = (char *) nvd_file;
+                }
+                dir = *path ? path : ".";
+        } else {
+                file = path;
+                dir = ".";
+        }
+
+        return cve_string_dup_printf("%s/.%s.%s", dir, file, suffix);
 }
 
 /*

--- a/src/library/util.h
+++ b/src/library/util.h
@@ -220,6 +220,16 @@ bool cve_is_dir(const char *p);
  */
 char *cve_get_file_parent(const char *p);
 
+/**
+ * Return absolute path to the dot file in format .basename(db_path).suffix
+ *
+ * @note This is an allocated string, and must be freed by the caller
+ * @param db_path Path to the database file
+ * @param suffix Suffix of the database file
+ * @return a newly allocated string or NULL in case of error
+ */
+cve_string *make_db_dot_fname(const char *db_path, const char *suffix);
+
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
  *

--- a/src/library/util.h
+++ b/src/library/util.h
@@ -154,6 +154,7 @@ DEF_AUTOFREE(GZlibDecompressor, g_object_unref)
 DEF_AUTOFREE(GKeyFile, g_key_file_unref)
 DEF_AUTOFREE(cve_string, cve_string_free)
 DEF_AUTOFREE(CveDB, cve_db_free)
+DEF_AUTOFREE(char, free)
 
 /**
  * Suger-utility: Determine if a string contains a certain word
@@ -181,6 +182,18 @@ static inline bool str_contains(const gchar *word, const gchar *needle)
  * @return A newly allocated string with the replacement performed
  */
 gchar *str_replace(gchar *source, const gchar *word, const gchar *replace);
+
+/**
+ * Determine if two nil terminated strings are equal
+ *
+ * @param s1 String compare against s2
+ * @param s2 String compare against s1
+ * @return a boolean value, true if two strings are equal
+ */
+static inline bool streq(const char *s1, const char *s2)
+{
+        return !strcmp(s1, s2);
+}
 
 /**
  * Determine if the given path exists on disk

--- a/src/main.c
+++ b/src/main.c
@@ -260,6 +260,7 @@ static bool hide_patched = false;
 static bool show_unaffected = false;
 static bool _show_version = false;
 static bool skip_update = false;
+static gchar *nvds = NULL;
 static gchar *forced_type = NULL;
 static bool no_html = false;
 static bool csv_mode = false;
@@ -272,6 +273,7 @@ static GOptionEntry _entries[] = {
         { "not-patched", 'n', 0, G_OPTION_ARG_NONE, &hide_patched, "Hide patched/addressed CVEs", NULL },
         { "not-affected", 'a', 0, G_OPTION_ARG_NONE, &show_unaffected, "Show unaffected items", NULL },
         { "skip-update", 'u', 0, G_OPTION_ARG_NONE, &skip_update, "Bypass forced updates", NULL },
+        { "nvd-dir", 'd', 0, G_OPTION_ARG_STRING, &nvds, "NVD directory in filesystem", NULL },
         { "version", 'v', 0, G_OPTION_ARG_NONE, &_show_version, "Show version", NULL },
         { "type", 't', 0, G_OPTION_ARG_STRING, &forced_type, "Set package type to T", "T" },
         { "no-html", 'N', 0, G_OPTION_ARG_NONE, &no_html, "Disable HTML report", NULL },
@@ -597,7 +599,7 @@ int main(int argc, char **argv)
                 goto cleanup;
         }
 
-        db_path = get_db_path(NULL);
+        db_path = get_db_path(nvds);
         if (!db_path) {
                 fprintf(stderr, "main(): Out of memory\n");
                 goto cleanup;

--- a/src/main.c
+++ b/src/main.c
@@ -405,15 +405,6 @@ static bool track_bugs(const gchar *auto_bug_template)
         return NULL;
 }
 
-static char *get_db_path(void)
-{
-        char *p = NULL;
-        if (!asprintf(&p, "%s/NVDS/nvd.db", g_get_home_dir())) {
-                return NULL;
-        }
-        return p;
-}
-
 /**
  * Attempt to gain the correct packaging plugin for the given path
  */
@@ -581,9 +572,8 @@ int main(int argc, char **argv)
         autofree(GOptionContext) *context = NULL;
         autofree(char) *target = NULL;
         autofree(GKeyFile) *config = NULL;
-        autofree(char) *db_path = NULL;
+        autofree(gchar) *db_path = NULL;
         autofree(CveDB) *cve_db = NULL;
-        autofree(gchar) *lockfile = NULL;
         GList *pkg_plugins = NULL;
         int ret = EXIT_FAILURE;
         CveCheckTool instance = { 0 };
@@ -607,21 +597,21 @@ int main(int argc, char **argv)
                 goto cleanup;
         }
 
-        db_path = get_db_path();
+        db_path = get_db_path(NULL);
         if (!db_path) {
-                fprintf(stderr, "main(): Out of memory\n");
-                goto cleanup;
-        }
-        lockfile = get_lock_file();
-        if (!lockfile) {
                 fprintf(stderr, "main(): Out of memory\n");
                 goto cleanup;
         }
 
         if (!skip_update) {
-                if (update_required() || cve_file_exists(lockfile)) {
+                int status = update_required(db_path);
+                if (status < 0) {
+                        fprintf(stderr, "Failed to check if db requires update\n");
+                        goto cleanup;
+                }
+                if (status) {
                         fprintf(stderr, "Update of db forced\n");
-                        if (!update_db(csv_mode)) {
+                        if (!update_db(csv_mode, db_path)) {
                                 fprintf(stderr, "DB update failure\n");
                                 goto cleanup;
                         }

--- a/src/main.c
+++ b/src/main.c
@@ -29,6 +29,7 @@
 #include "plugins/jira/jira.h"
 #include "config.h"
 #include "cve-string.h"
+#include "cve-db-lock.h"
 #include "core.h"
 
 #include "update.h"
@@ -580,14 +581,14 @@ int main(int argc, char **argv)
         CvePlugin *report = NULL;
         CvePlugin *package = NULL;
         LIBXML_TEST_VERSION
-        bool quiet;
+        bool quiet, db_locked;
 
         self = &instance;
         context = g_option_context_new(" - cve check tool");
         g_option_context_add_main_entries(context, _entries, NULL);
         if (!g_option_context_parse(context, &argc, &argv, &error)) {
                 g_printerr("Invalid options: %s\n", error->message);
-                goto cleanup;
+                goto cleanup_no_lock;
         }
 
         quiet = csv_mode || !no_html;
@@ -595,12 +596,24 @@ int main(int argc, char **argv)
         if (_show_version) {
                 show_version();
                 ret = EXIT_SUCCESS;
-                goto cleanup;
+                goto cleanup_no_lock;
         }
 
         db_path = get_db_path(nvds);
         if (!db_path) {
                 fprintf(stderr, "main(): Out of memory\n");
+                goto cleanup_no_lock;
+        }
+
+        db_locked = cve_db_lock_init(db_path);
+        if (!db_locked) {
+                fprintf(stderr, "Not continuing without a database %s\n", "lock");
+                goto cleanup_no_lock;
+        }
+
+        db_locked = cve_db_read_lock(LOCK_WAIT_SECS);
+        if (!db_locked) {
+                fputs("Exiting...\n", stderr);
                 goto cleanup;
         }
 
@@ -612,6 +625,7 @@ int main(int argc, char **argv)
                 }
                 if (status) {
                         fprintf(stderr, "Update of db forced\n");
+                        cve_db_unlock();
                         if (!update_db(quiet, db_path)) {
                                 fprintf(stderr, "DB update failure\n");
                                 goto cleanup;
@@ -619,7 +633,7 @@ int main(int argc, char **argv)
                 }
         } else {
                 if (!cve_file_exists(db_path)) {
-                        fprintf(stderr, "Not continuing without a database\n");
+                        fprintf(stderr, "Not continuing without a database %s\n", "file");
                         goto cleanup;
                 }
         }
@@ -894,6 +908,9 @@ clean:
         ret = EXIT_SUCCESS;
 
 cleanup:
+        cve_db_lock_fini();
+
+cleanup_no_lock:
         if (pkg_plugins) {
                 g_list_free(pkg_plugins);
         }

--- a/src/main.c
+++ b/src/main.c
@@ -584,6 +584,7 @@ int main(int argc, char **argv)
         CvePlugin *report = NULL;
         CvePlugin *package = NULL;
         LIBXML_TEST_VERSION
+        bool quiet;
 
         self = &instance;
         context = g_option_context_new(" - cve check tool");
@@ -592,6 +593,8 @@ int main(int argc, char **argv)
                 g_printerr("Invalid options: %s\n", error->message);
                 goto cleanup;
         }
+
+        quiet = csv_mode || !no_html;
 
         if (_show_version) {
                 show_version();
@@ -613,7 +616,7 @@ int main(int argc, char **argv)
                 }
                 if (status) {
                         fprintf(stderr, "Update of db forced\n");
-                        if (!update_db(csv_mode, db_path)) {
+                        if (!update_db(quiet, db_path)) {
                                 fprintf(stderr, "DB update failure\n");
                                 goto cleanup;
                         }
@@ -863,7 +866,7 @@ clean:
                 goto cleanup;
         }
         /* Consider a verbosity flag... */
-        if (!csv_mode) {
+        if (!quiet) {
                 fprintf(stderr, "Scanned %d source file%s\n", size, size > 1 ? "s" : "");
         }
 

--- a/src/main.c
+++ b/src/main.c
@@ -44,10 +44,6 @@ static char *srpm_dir = NULL;
 #define DEFAULT_CONFIG_FILE     DEFAULT_PATH    "/cve-check-tool.conf"
 #define SITE_CONFIG_FILE        SITE_PATH       "/cve-check-tool.conf"
 
-DEF_AUTOFREE(char, free)
-
-#define streq(x,y) strcmp(x,y) == 0
-
 
 /**
  * Helper utility to free a struct source_package_t

--- a/src/main.c
+++ b/src/main.c
@@ -745,10 +745,6 @@ int main(int argc, char **argv)
         self->show_unaffected = show_unaffected;
         instance.db = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, package_free);
         instance.bdb = NULL;
-        /* Automatically disable HTML output in CSV mode */
-        if (csv_mode) {
-                no_html = true;
-        }
 
         if (is_package_list(target)) {
                 /* Packages file */
@@ -880,32 +876,23 @@ clean:
          */
         if (csv_mode) {
                 report = cve_plugin_get_by_name("csv");
+        } else if (!no_html) {
+                report = cve_plugin_get_by_name("html");
         } else {
                 report = cve_plugin_get_by_name("cli");
         }
+
         if (!report || !report->report) {
                 fprintf(stderr, "No usable output module\n");
                 goto cleanup;
         }
 
         if (!report->report(self)) {
+                fprintf(stderr, "Report generation failed\n");
                 goto cleanup;
         }
 
-        if (!no_html) {
-                report = cve_plugin_get_by_name("html");
-                if (!report || !report->report) {
-                        fprintf(stderr, "html module is missing\n");
-                        goto cleanup;
-                }
-                if (!report->report(self)) {
-                        fprintf(stderr, "Report generation failed\n");
-                } else {
-                        ret = EXIT_SUCCESS;
-                }
-        } else {
-                ret = EXIT_SUCCESS;
-        }
+        ret = EXIT_SUCCESS;
 
 cleanup:
         if (pkg_plugins) {

--- a/src/plugins/jira/jira.c
+++ b/src/plugins/jira/jira.c
@@ -237,6 +237,7 @@ bool build_new_jira_issue_file(const gchar *path, const gchar *summary, const gc
         autofree(gchar) *data = NULL;
         autofree(gchar) *summary_tmp = g_strdup(summary);
         autofree(gchar) *description_tmp = g_strdup(description);
+        autofree(cve_string) *j_json = NULL;
 
         if (!is_initialized()) {
                 return false;
@@ -251,7 +252,8 @@ bool build_new_jira_issue_file(const gchar *path, const gchar *summary, const gc
         if (description_tmp != NULL) {
                 g_hash_table_insert(g_jira_cfg->template,"description", summary_tmp);
         }
-        *jira_json = g_strdup(template_string(data, g_jira_cfg->template));
+        j_json = template_string(data, g_jira_cfg->template);
+        *jira_json = g_strdup(j_json->str);
         if (summary_tmp != NULL) {
                 g_hash_table_remove(g_jira_cfg->template,"summary");
         }

--- a/src/plugins/output/cli/cli.c
+++ b/src/plugins/output/cli/cli.c
@@ -35,22 +35,23 @@ static bool cli_write_report(CveCheckTool *self)
                 if (!v->issues && self->hide_patched) {
                         continue;
                 }
-                fprintf(stderr, "%s %s (%u patched, %u issues)\n"C_WHITE"------------"C_RESET"\n", key, (char*)v->version, g_list_length(v->patched), g_list_length(v->issues));
+                fprintf(stdout, "%s %s (%u patched, %u issues)\n"C_WHITE"------------"C_RESET"\n",
+                        key, (char*)v->version, g_list_length(v->patched), g_list_length(v->issues));
                 for (c = v->issues; c; c = c->next) {
                         entry = cve_db_get_cve(self->cve_db, (gchar*)c->data);
                         if (self->modified > 0 && entry->modified > self->modified) {
                                 cve_free(entry);
                                 continue;
                         }
-                        fprintf(stderr, " * "C_RED"%s"C_RESET" : %s\n\n", (char*)c->data, entry->summary);
+                        fprintf(stdout, " * "C_RED"%s"C_RESET" : %s\n\n", (char*)c->data, entry->summary);
                         /* Print links.. */
                         bool p = false;
                         for (t = entry->uris; t; t = t->next) {
-                                fprintf(stderr, "     - %s\n", (char*)t->data);
+                                fprintf(stdout, "     - %s\n", (char*)t->data);
                                 p = true;
                         }
                         if (p) {
-                                fprintf(stderr, "\n");
+                                fprintf(stdout, "\n");
                         }
                         cve_free(entry);
                 }
@@ -61,11 +62,11 @@ static bool cli_write_report(CveCheckTool *self)
                                         cve_free(entry);
                                         continue;
                                 }
-                                fprintf(stderr, " * "C_BLUE"%s [PATCHED]"C_RESET" : %s\n\n", (char*)c->data, entry->summary);
+                                fprintf(stdout, " * "C_BLUE"%s [PATCHED]"C_RESET" : %s\n\n", (char*)c->data, entry->summary);
                                 cve_free(entry);
                         }
                 }
-                fprintf(stderr, "\n");
+                fputc('\n', stdout);
         }
         return true;
 }

--- a/src/plugins/output/html/html.c
+++ b/src/plugins/output/html/html.c
@@ -11,10 +11,14 @@
 
 #define _GNU_SOURCE
 
+#include <stdio.h>
+#include <errno.h>
+
 #include "config.h"
 #include "util.h"
 #include "template.h"
 #include "cve-check-tool.h"
+#include "cve-string.h"
 #include "plugin.h"
 
 #define TMPL(X) DATA_DIRECTORY G_DIR_SEPARATOR_S X ".template"
@@ -72,10 +76,9 @@ static inline gchar *status_map(ReportStatus status)
 
 static bool write_report(CveCheckTool *self)
 {
-        autofree(GError) *error = NULL;
         autofree(gchar) *aff = NULL;
         autofree(gchar) *body = NULL;
-        autofree(gchar) *ret = NULL;
+        autofree(cve_string) *report = NULL;
         GHashTableIter iter;
         gchar *key = NULL;
         struct source_package_t *v = NULL;
@@ -84,7 +87,7 @@ static bool write_report(CveCheckTool *self)
         gint affected = 0;
         guint row = 0;
         autofree(TemplateContext) *context = NULL;
-        const char *filename = "report.html";
+        int ret;
 
         /* Mandatory template files */
         LOAD_TEMPLATE(TMPL_TOTAL, &body);
@@ -166,11 +169,16 @@ static bool write_report(CveCheckTool *self)
                 affected > 1 ? "s" : "");
 
         template_context_add_string(context, "affected_string", aff);
-        ret = template_context_process_line(context, body, false);
+        report = template_context_process_line(context, body, false);
 
-        /* Write file */
-        if (!g_file_set_contents(filename, ret, -1, &error)) {
-                g_printerr("Unable to write report: %s\n", error->message);
+        /* Write report */
+        ret = printf("%s\n", report->str);
+        if (ret < 0) {
+                g_printerr("Unable to write report: %s\n", strerror(errno));
+                return false;
+        }
+        if (!ret || ret != cstrlen(report) + 1) {
+                g_printerr("Report was truncated\n");
                 return false;
         }
 

--- a/src/update-main.c
+++ b/src/update-main.c
@@ -39,10 +39,12 @@ the Free Software Foundation; either version 2 of the License, or\n\
         fprintf(stderr, "%s\n", msg);
 }
 
+static gchar *nvds = NULL;
 static bool _show_version = false;
 static bool _quiet = false;
 
 static GOptionEntry _entries[] = {
+        { "nvd-dir", 'd', 0, G_OPTION_ARG_STRING, &nvds, "NVD directory in filesystem", NULL },
         { "version", 'v', 0, G_OPTION_ARG_NONE, &_show_version, "Show version", NULL },
         { "quiet", 'q', 0, G_OPTION_ARG_NONE, &_quiet, "Run silently", NULL },
         { .short_name = 0 }
@@ -72,7 +74,7 @@ int main(int argc, char **argv)
                 goto end;
         }
 
-        db_path = get_db_path(NULL);
+        db_path = get_db_path(nvds);
         if (!db_path) {
                 fprintf(stderr, "main(): Out of memory\n");
                 goto end;

--- a/src/update-main.c
+++ b/src/update-main.c
@@ -23,6 +23,7 @@
 #include "util.h"
 #include "config.h"
 #include "cve-string.h"
+#include "cve-db-lock.h"
 #include "core.h"
 
 #include "update.h"
@@ -59,6 +60,7 @@ int main(int argc, char **argv)
         autofree(GOptionContext) *context = NULL;
         autofree(gchar) *db_path = NULL;
         int ret = EXIT_FAILURE;
+        bool db_locked;
 
         LIBXML_TEST_VERSION
         context = g_option_context_new(" - cve update");
@@ -80,12 +82,19 @@ int main(int argc, char **argv)
                 goto end;
         }
 
+        db_locked = cve_db_lock_init(db_path);
+        if (!db_locked) {
+                fputs("Not continuing without a database lock\n", stderr);
+                goto end;
+        }
+
         if (update_db(_quiet, db_path)) {
                 ret = EXIT_SUCCESS;
         } else {
                 fprintf(stderr, "Failed to update database\n");
         }
 
+        cve_db_lock_fini();
 end:
         xmlCleanupParser();
         return ret;

--- a/src/update-main.c
+++ b/src/update-main.c
@@ -55,6 +55,7 @@ int main(int argc, char **argv)
 {
         autofree(GError) *error = NULL;
         autofree(GOptionContext) *context = NULL;
+        autofree(gchar) *db_path = NULL;
         int ret = EXIT_FAILURE;
 
         LIBXML_TEST_VERSION
@@ -71,7 +72,13 @@ int main(int argc, char **argv)
                 goto end;
         }
 
-        if (update_db(_quiet)) {
+        db_path = get_db_path(NULL);
+        if (!db_path) {
+                fprintf(stderr, "main(): Out of memory\n");
+                goto end;
+        }
+
+        if (update_db(_quiet, db_path)) {
                 ret = EXIT_SUCCESS;
         } else {
                 fprintf(stderr, "Failed to update database\n");

--- a/src/update.c
+++ b/src/update.c
@@ -10,15 +10,19 @@
  */
 
 #define _GNU_SOURCE
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
 #include <stdint.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <utime.h>
 #include <glib.h>
 #include <gio/gio.h>
 #include <curl/curl.h>
-#include <sys/stat.h>
 
 #include "cve-check-tool.h"
 
@@ -35,6 +39,7 @@
 #include "fetch.h"
 
 #define UPDATE_THRESHOLD 7200
+#define UPDATE_DB_MARKER_SUFFIX	"cve.update_db"
 
 gchar *get_db_path(const gchar *path)
 {
@@ -47,27 +52,70 @@ gchar *get_db_path(const gchar *path)
         return g_build_path(G_DIR_SEPARATOR_S, path, nvds, nvd_file, NULL);
 }
 
-static bool __update_required(const char *db_file)
+static bool __update_required(const char *db_file, const char *update_fname)
 {
         struct stat st;
         time_t t;
 
         memset(&st, 0, sizeof(st));
         if (stat(db_file, &st)) {
-                return true;
+                goto end;
+        }
+
+        if (!st.st_size) {
+                goto unlink;
         }
 
         t = time(NULL);
         if (difftime(t, st.st_mtime) >= UPDATE_THRESHOLD) {
-                return true;
+                goto end;
+        }
+
+        memset(&st, 0, sizeof(st));
+        if (!stat(update_fname, &st)) {
+                goto unlink;
         }
 
         return false;
+unlink:
+        /* Database partial load: unlink it to load again */
+        unlink(db_file);
+end:
+        return true;
 }
 
 int update_required(const char *db_file)
 {
-        return __update_required(db_file);
+        autofree(cve_string) *u_fname = NULL;
+
+        u_fname = make_db_dot_fname(db_file, UPDATE_DB_MARKER_SUFFIX);
+        if (!u_fname) {
+                return -1;
+        }
+
+        return __update_required(db_file, u_fname->str);
+}
+
+#ifndef O_NOFOLLOW
+#define O_NOFOLLOW      0
+#endif
+
+static inline int update_begin(const char *update_fname)
+{
+        const int flags = O_RDONLY|O_CREAT|O_NONBLOCK|O_NOFOLLOW;
+        const mode_t mode = S_IRUSR|S_IWUSR;
+
+        return open(update_fname, flags, mode);
+}
+
+static inline void update_end(int fd, const char *update_fname, bool ok)
+{
+        if (fd >= 0) {
+                close(fd);
+                if (ok) {
+                        unlink(update_fname);
+                }
+        }
 }
 
 bool update_db(bool quiet, const char *db_file)
@@ -75,10 +123,18 @@ bool update_db(bool quiet, const char *db_file)
         autofree(gchar) *db_dir = NULL;
         autofree(CveDB) *cve_db = NULL;
         autofree(GDateTime) *date = NULL;
+        autofree(cve_string) *u_fname = NULL;
+        int u_handle = -1;
         int year;
         bool ret = false;
         bool db_exist = false;
         bool db_locked;
+
+        u_fname = make_db_dot_fname(db_file, UPDATE_DB_MARKER_SUFFIX);
+        if (!u_fname) {
+                fputs("update_db(): Out of memory\n", stderr);
+                goto end_no_lock;
+        }
 
         db_locked = cve_db_write_lock(LOCK_WAIT_SECS);
         if (!db_locked) {
@@ -87,7 +143,7 @@ bool update_db(bool quiet, const char *db_file)
         }
 
         /* Lock aquired, check if database is still needs update */
-        if (!__update_required(db_file)) {
+        if (!__update_required(db_file, u_fname->str)) {
                 ret = true;
                 goto end;
         }
@@ -104,6 +160,12 @@ bool update_db(bool quiet, const char *db_file)
                         fprintf(stderr, "Unable to create required directory: %s\n", db_dir);
                         goto end;
                 }
+        }
+
+        u_handle = update_begin(u_fname->str);
+        if (u_handle < 0) {
+                fprintf(stderr, "Can't create timestamp file %s\n", u_fname->str);
+                goto end;
         }
 
         cve_db = cve_db_new(db_file);
@@ -159,9 +221,17 @@ bool update_db(bool quiet, const char *db_file)
                 }
         }
 
-        ret = true;
+        /* Make sure we always update access and modify time on
+         * database file, even if no new data loaded.
+         */
+        if (utime(db_file, NULL)) {
+                fprintf(stderr, "Unable to update file access and modify time\n");
+                goto end;
+        }
 
+        ret = true;
 end:
+        update_end(u_handle, u_fname->str, ret);
         cve_db_unlock();
 end_no_lock:
         return ret;

--- a/src/update.c
+++ b/src/update.c
@@ -71,6 +71,15 @@ end:
         return ret;
 }
 
+static cve_string *nvdcve_make_fname(int year, const char *fext)
+{
+        if (year < 0) {
+                return cve_string_dup_printf("nvdcve-2.0-Modified.%s", fext);
+        } else {
+                return cve_string_dup_printf("nvdcve-2.0-%d.%s", year, fext);
+        }
+}
+
 static bool __update_required(const char *db_file, const char *update_fname)
 {
         struct stat st;
@@ -187,49 +196,53 @@ bool update_db(bool quiet, const char *db_file)
         year = g_date_time_get_year(date);
 
         for (int i = YEAR_START; i <= year+1; i++) {
-                autofree(gchar) *uri = NULL;
-                autofree(gchar) *target = NULL;
+                autofree(cve_string) *uri = NULL;
+                autofree(cve_string) *target = NULL;
+                autofree(cve_string) *nvd_xml_gz = NULL;
                 FetchStatus st;
                 bool update = false;
 
-                if (i > year) {
-                        uri = g_strdup_printf("%s/nvdcve-2.0-Modified.xml.gz", URI_PREFIX);
-                        target = g_strdup_printf("%s/nvdcve-2.0-Modified.xml.gz", db_dir);
-                } else {
-                        uri = g_strdup_printf("%s/nvdcve-2.0-%d.xml.gz", URI_PREFIX, i);
-                        target = g_strdup_printf("%s/nvdcve-2.0-%d.xml.gz", db_dir, i);
-                }
-
-                if (!uri || !target) {
+                nvd_xml_gz = nvdcve_make_fname(i > year ? -1 : i, "xml.gz");
+                if (!nvd_xml_gz) {
                         goto oom;
                 }
 
-                st = fetch_uri(uri, target, !quiet);
+                target = cve_string_dup_printf("%s/%s", db_dir, nvd_xml_gz->str);
+                if (!target) {
+                        goto oom;
+                }
+
+                uri = cve_string_dup_printf("%s/%s", nvd_uri, nvd_xml_gz->str);
+                if (!uri) {
+                        goto oom;
+                }
+
+                st = fetch_uri(uri->str, target->str, !quiet);
                 switch (st) {
                         case FETCH_STATUS_FAIL:
-                                fprintf(stderr, "Failed to fetch %s\n", uri);
+                                fprintf(stderr, "Failed to fetch %s\n", uri->str);
                                 goto end;
                         case FETCH_STATUS_UPDATE:
                                 update = true;
                                 break;
                         default:
                                 if (!quiet) {
-                                        fprintf(stderr, "Skipping: %s\n", basename(target));
+                                        fprintf(stderr, "Skipping: %s\n", nvd_xml_gz->str);
                                 }
                                 break;
                 }
                 if (update || !db_exist) {
                         /* Only load on updates */
-                        if (!gunzip_file(target)) {
-                                fprintf(stderr, "Unable to extract %s\n", target);
+                        if (!gunzip_file(target->str)) {
+                                fprintf(stderr, "Unable to extract %s\n", target->str);
                                 goto end;
                         }
-                        if (!cve_db_load(cve_db, target)) {
-                                fprintf(stderr, "\nUnable to find: %s\n", target);
+                        if (!cve_db_load(cve_db, target->str)) {
+                                fprintf(stderr, "\nUnable to find: %s\n", target->str);
                                 goto end;
                         }
                         if (!quiet) {
-                                fprintf(stderr, "Loaded: %s\n", basename(target));
+                                fprintf(stderr, "Loaded: %s\n", nvd_xml_gz->str);
                         }
                 }
         }

--- a/src/update.c
+++ b/src/update.c
@@ -37,41 +37,19 @@
 #define URI_PREFIX "http://static.nvd.nist.gov/feeds/xml/cve"
 #include "fetch.h"
 
-static bool do_unlock(void);
-
-static gchar *get_db_path(void)
-{
-        return g_build_path(G_DIR_SEPARATOR_S, g_get_home_dir(), "NVDS", "nvd.db", NULL);
-}
-
-gchar *get_lock_file(void)
-{
-        return g_build_path(G_DIR_SEPARATOR_S, g_get_home_dir(), "NVDS", "nvd.lock", NULL);
-}
-
 #define UPDATE_THRESHOLD 7200
 /* Wait at most 5 minutes for a parallel client */
 #define UPDATE_WAIT 300
 
+static bool do_unlock(void);
+
 static bool reg = false;
+static gchar *lock_file;
 static volatile int lock_fd = -1;
 
-bool update_required()
+static gchar *get_lock_file(const gchar *db_dir)
 {
-        time_t t;
-
-        autofree(gchar) *db = get_db_path();
-        struct stat st = {.st_ino = 0};
-        if (stat(db, &st) != 0) {
-                return true;
-        }
-
-        t = time(NULL);
-        if (difftime(t, st.st_mtime) >= UPDATE_THRESHOLD) {
-                return true;
-        }
-
-        return false;
+        return g_build_path(G_DIR_SEPARATOR_S, db_dir, "nvd.lock", NULL);
 }
 
 static void exit_unlock(void)
@@ -87,39 +65,54 @@ static void exit_unlock_sig(int sig)
         exit(sig);
 }
 
-static bool do_lock(gchar *path)
+static bool do_lock(const gchar *lfile)
 {
-        int fd = 0;
-        int res = 0;
-        struct flock lock = { 0 };
+        struct flock lock = { .l_type = F_WRLCK, };
+        int fd;
 
-
-        if ((fd = open(path, O_WRONLY|O_CREAT|O_NONBLOCK, S_IRUSR|S_IWUSR)) < 0) {
-                return false;
+        lfile = g_strdup(lfile);
+        if (!lfile) {
+                goto err_out;
         }
 
-        lock.l_type = F_WRLCK;
-        if ((res = fcntl(fd, F_SETLK, &lock)) < 0) {
-                close(fd);
-                /* File existence is enough */
-                fprintf(stderr, "do_lock(): Failed to gain exclusive lock: %s\n", strerror(errno));
-                return false;
+        fd = open(lfile, O_WRONLY|O_CREAT|O_NONBLOCK, S_IRUSR|S_IWUSR);
+        if (fd < 0) {
+                goto err_free;
         }
+
+        if (fcntl(fd, F_SETLK, &lock)) {
+                goto err_lock;
+        }
+
+        /* Lock aquired, store lock configuration before registering
+         * signal and atexit() handlers to let them unconfigure
+         * gracefully.
+         */
+        lock_file = lfile;
+        lock_fd = fd;
+
         if (!reg) {
                 reg = true;
                 signal(SIGINT, exit_unlock_sig);
                 atexit(exit_unlock);
         }
 
-        lock_fd = fd;
         return true;
+
+err_lock:
+        /* File existence is enough */
+        fprintf(stderr, "do_lock(): Failed to gain exclusive lock: %s\n", strerror(errno));
+        close(fd);
+err_free:
+        g_free(lfile);
+err_out:
+        return false;
 }
 
 
 static bool do_unlock()
 {
         struct flock lock = { 0 };
-        autofree(gchar) *lfile = NULL;
         bool ret = true;
 
         if (lock_fd < 0) {
@@ -137,17 +130,13 @@ static bool do_unlock()
         close(lock_fd);
         lock_fd = -1;
 
-        lfile = get_lock_file();
-        if (!lfile) {
-                fprintf(stderr, "do_unlock(): Out of memory\n");
+        if (unlink(lock_file) != 0) {
+                fprintf(stderr, "do_unlock(): Lockfile not removed, will cause issues.");
                 ret = false;
-        } else {
-                if (unlink(lfile) != 0) {
-                        fprintf(stderr, "do_unlock(): Lockfile not removed, will cause issues.");
-                        ret = false;
-                }
         }
 
+        g_free(lock_file);
+        lock_file = NULL;
 
         return ret;
 }
@@ -171,57 +160,106 @@ static bool wait_file(gchar *path, int timeout)
         }
 }
 
-bool update_db(bool quiet)
+gchar *get_db_path(const gchar *path)
 {
-        autofree(gchar) *db_path = NULL;
-        autofree(cve_string) *workdir = NULL;
+        const gchar *nvds_dir = "";
+
+        if (!path || !*path) {
+                path = g_get_home_dir();
+                nvds_dir = "NVDS";
+        }
+
+        return g_build_path(G_DIR_SEPARATOR_S, path, nvds_dir, "nvd.db", NULL);
+}
+
+static bool __update_required(const char *db_file, const char *lfile)
+{
+        struct stat st;
+        time_t t;
+
+        memset(&st, 0, sizeof(st));
+        if (stat(lfile, &st)) {
+                return true;
+        }
+
+        memset(&st, 0, sizeof(st));
+        if (stat(db_file, &st)) {
+                return true;
+        }
+
+        t = time(NULL);
+        if (difftime(t, st.st_mtime) >= UPDATE_THRESHOLD) {
+                return true;
+        }
+
+        return false;
+}
+
+int update_required(const char *db_file)
+{
+        autofree(gchar) *db_dir = NULL;
+        autofree(gchar) *lfile = NULL;
+
+        db_dir = g_path_get_dirname(db_file);
+        if (!db_dir) {
+                return -1;
+        }
+
+        lfile = get_lock_file(db_dir);
+        if (!lfile) {
+                return -1;
+        }
+
+        return __update_required(db_file, lfile);
+}
+
+bool update_db(bool quiet, const char *db_file)
+{
+        autofree(gchar) *db_dir = NULL;
         autofree(CveDB) *cve_db = NULL;
-        __attribute__ ((unused)) struct stat st;
         autofree(GDateTime) *date = NULL;
-        autofree(gchar) *lock_file = NULL;
+        autofree(gchar) *lfile = NULL;
         int year;
         bool ret = false;
         bool db_exist = false;
 
-        db_path = get_db_path();
-        if (!db_path) {
+        db_dir = g_path_get_dirname(db_file);
+        if (!db_dir) {
                 fprintf(stderr, "update_db(): Out of memory\n");
                 goto end;
         }
 
-        lock_file = get_lock_file();
-        if (!lock_file) {
+        lfile = get_lock_file(db_dir);
+        if (!lfile) {
                 fprintf(stderr, "update_db(): Out of memory\n");
                 goto end;
         }
 
-        if (cve_file_exists(lock_file)) {
-                if (!wait_file(lock_file, UPDATE_WAIT)) {
+        if (cve_file_exists(lfile)) {
+                if (!wait_file(lfile, UPDATE_WAIT)) {
                         fprintf(stderr, "update_db(): Waited too long for parallel update\n");
                         goto end;
                 }
-                if (!update_required()) {
+                if (!__update_required(db_file, lfile)) {
                         return true;
                 }
         }
 
-        db_exist = cve_file_exists(db_path);
-
-        workdir = cve_string_dup_printf("%s/NVDS/", g_get_home_dir());
-        if (stat(workdir->str, &st) != 0) {
-                if (mkdir(workdir->str, 0777) != 0) {
-                        fprintf(stderr, "Unable to create required directory: %s\n", workdir->str);
+        db_exist = cve_file_exists(db_file);
+        if (!db_exist && !cve_file_exists(db_dir)) {
+                if (mkdir(db_dir, S_IRWXU|S_IRWXG|S_IRWXO)) {
+                        fprintf(stderr, "Unable to create required directory: %s\n", db_dir);
                         goto end;
                 }
         }
 
         /* Go and lock now. */
-        if (!do_lock(lock_file)) {
+        if (!do_lock(lfile)) {
                 fprintf(stderr, "update_db(): Cannot get lock file\n");
                 return false;
         }
 
-        cve_db = cve_db_new(db_path);
+        cve_db = cve_db_new(db_file);
         if (!cve_db) {
                 fprintf(stderr, "main(): DB initialisation issue\n");
                 goto end;
@@ -238,10 +276,10 @@ bool update_db(bool quiet)
 
                 if (i > year) {
                         uri = g_strdup_printf("%s/nvdcve-2.0-Modified.xml.gz", URI_PREFIX);
-                        target = g_strdup_printf("%s/NVDS/nvdcve-2.0-Modified.xml.gz", g_get_home_dir());
+                        target = g_strdup_printf("%s/nvdcve-2.0-Modified.xml.gz", db_dir);
                 } else {
                         uri = g_strdup_printf("%s/nvdcve-2.0-%d.xml.gz", URI_PREFIX, i);
-                        target = g_strdup_printf("%s/NVDS/nvdcve-2.0-%d.xml.gz", g_get_home_dir(), i);
+                        target = g_strdup_printf("%s/nvdcve-2.0-%d.xml.gz", db_dir, i);
                 }
 
                 st = fetch_uri(uri, target, !quiet);

--- a/src/update.c
+++ b/src/update.c
@@ -144,6 +144,64 @@ static inline void update_end(int fd, const char *update_fname, bool ok)
         }
 }
 
+static int do_fetch_update(int year, const char *db_dir, CveDB *cve_db,
+                           bool db_exist, bool verbose)
+{
+        const char nvd_uri[] = URI_PREFIX;
+        autofree(cve_string) *uri = NULL;
+        autofree(cve_string) *target = NULL;
+        autofree(cve_string) *nvd_xml_gz = NULL;
+        FetchStatus st;
+        bool update = false;
+
+        nvd_xml_gz = nvdcve_make_fname(year, "xml.gz");
+        if (!nvd_xml_gz) {
+                return ENOMEM;
+        }
+
+        target = cve_string_dup_printf("%s/%s", db_dir, nvd_xml_gz->str);
+        if (!target) {
+                return ENOMEM;
+        }
+
+        uri = cve_string_dup_printf("%s/%s", nvd_uri, nvd_xml_gz->str);
+        if (!uri) {
+                return ENOMEM;
+        }
+
+        st = fetch_uri(uri->str, target->str, verbose);
+        switch (st) {
+        case FETCH_STATUS_FAIL:
+                fprintf(stderr, "Failed to fetch %s\n", uri->str);
+                return -1;
+        case FETCH_STATUS_UPDATE:
+                update = true;
+                break;
+        default:
+                if (verbose) {
+                        fprintf(stderr, "Skipping: %s\n", nvd_xml_gz->str);
+                }
+                break;
+        }
+
+        if (update || !db_exist) {
+                /* Only load on updates */
+                if (!gunzip_file(target->str)) {
+                        fprintf(stderr, "Unable to extract %s\n", target->str);
+                        return -1;
+                }
+                if (!cve_db_load(cve_db, target->str)) {
+                        fprintf(stderr, "\nUnable to find: %s\n", target->str);
+                        return -1;
+                }
+                if (verbose) {
+                        fprintf(stderr, "Loaded: %s\n", nvd_xml_gz->str);
+                }
+        }
+
+        return 0;
+}
+
 bool update_db(bool quiet, const char *db_file)
 {
         autofree(gchar) *db_dir = NULL;
@@ -196,54 +254,17 @@ bool update_db(bool quiet, const char *db_file)
         year = g_date_time_get_year(date);
 
         for (int i = YEAR_START; i <= year+1; i++) {
-                autofree(cve_string) *uri = NULL;
-                autofree(cve_string) *target = NULL;
-                autofree(cve_string) *nvd_xml_gz = NULL;
-                FetchStatus st;
-                bool update = false;
+                int y = i > year ? -1 : i;
+                int rc;
 
-                nvd_xml_gz = nvdcve_make_fname(i > year ? -1 : i, "xml.gz");
-                if (!nvd_xml_gz) {
+                rc = do_fetch_update(y, db_dir, cve_db, db_exist, !quiet);
+                switch (rc) {
+                case 0:
+                        continue;
+                case ENOMEM:
                         goto oom;
-                }
-
-                target = cve_string_dup_printf("%s/%s", db_dir, nvd_xml_gz->str);
-                if (!target) {
-                        goto oom;
-                }
-
-                uri = cve_string_dup_printf("%s/%s", nvd_uri, nvd_xml_gz->str);
-                if (!uri) {
-                        goto oom;
-                }
-
-                st = fetch_uri(uri->str, target->str, !quiet);
-                switch (st) {
-                        case FETCH_STATUS_FAIL:
-                                fprintf(stderr, "Failed to fetch %s\n", uri->str);
-                                goto end;
-                        case FETCH_STATUS_UPDATE:
-                                update = true;
-                                break;
-                        default:
-                                if (!quiet) {
-                                        fprintf(stderr, "Skipping: %s\n", nvd_xml_gz->str);
-                                }
-                                break;
-                }
-                if (update || !db_exist) {
-                        /* Only load on updates */
-                        if (!gunzip_file(target->str)) {
-                                fprintf(stderr, "Unable to extract %s\n", target->str);
-                                goto end;
-                        }
-                        if (!cve_db_load(cve_db, target->str)) {
-                                fprintf(stderr, "\nUnable to find: %s\n", target->str);
-                                goto end;
-                        }
-                        if (!quiet) {
-                                fprintf(stderr, "Loaded: %s\n", nvd_xml_gz->str);
-                        }
+                default:
+                        goto end;
                 }
         }
 

--- a/src/update.c
+++ b/src/update.c
@@ -20,6 +20,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <utime.h>
+#include <errno.h>
 #include <glib.h>
 #include <gio/gio.h>
 #include <curl/curl.h>
@@ -43,13 +44,31 @@
 
 gchar *get_db_path(const gchar *path)
 {
-        const gchar *nvds = "";
+        const mode_t mode = S_IRWXU|S_IRWXG|S_IRWXO;
+        gchar *dir, *ret = NULL;
 
         if (!path || !*path) {
-                path = g_get_home_dir();
-                nvds = nvd_dir;
+                const gchar *home = g_get_home_dir();
+                dir = g_build_path(G_DIR_SEPARATOR_S, home, nvd_dir, NULL);
+        } else {
+                dir = (gchar *) path;
         }
-        return g_build_path(G_DIR_SEPARATOR_S, path, nvds, nvd_file, NULL);
+
+        if (mkdir(dir, mode)) {
+                struct stat st = { .st_ino = 0, };
+
+                if (errno != EEXIST)
+                        goto end;
+
+                if (stat(dir, &st) || !S_ISDIR(st.st_mode))
+                        goto end;
+        }
+
+        ret = g_build_path(G_DIR_SEPARATOR_S, dir, nvd_file, NULL);
+end:
+        if (dir != path)
+                g_free(dir);
+        return ret;
 }
 
 static bool __update_required(const char *db_file, const char *update_fname)
@@ -154,19 +173,13 @@ bool update_db(bool quiet, const char *db_file)
                 goto end;
         }
 
-        db_exist = cve_file_exists(db_file);
-        if (!db_exist && !cve_file_exists(db_dir)) {
-                if (mkdir(db_dir, S_IRWXU|S_IRWXG|S_IRWXO)) {
-                        fprintf(stderr, "Unable to create required directory: %s\n", db_dir);
-                        goto end;
-                }
-        }
-
         u_handle = update_begin(u_fname->str);
         if (u_handle < 0) {
                 fprintf(stderr, "Can't create timestamp file %s\n", u_fname->str);
                 goto end;
         }
+
+        db_exist = cve_file_exists(db_file);
 
         cve_db = cve_db_new(db_file);
         if (!cve_db) {

--- a/src/update.c
+++ b/src/update.c
@@ -162,14 +162,13 @@ static bool wait_file(gchar *path, int timeout)
 
 gchar *get_db_path(const gchar *path)
 {
-        const gchar *nvds_dir = "";
+        const gchar *nvds = "";
 
         if (!path || !*path) {
                 path = g_get_home_dir();
-                nvds_dir = "NVDS";
+                nvds = nvd_dir;
         }
-
-        return g_build_path(G_DIR_SEPARATOR_S, path, nvds_dir, "nvd.db", NULL);
+        return g_build_path(G_DIR_SEPARATOR_S, path, nvds, nvd_file, NULL);
 }
 
 static bool __update_required(const char *db_file, const char *lfile)

--- a/src/update.c
+++ b/src/update.c
@@ -19,16 +19,13 @@
 #include <gio/gio.h>
 #include <curl/curl.h>
 #include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <errno.h>
-#include <signal.h>
 
 #include "cve-check-tool.h"
 
 #include "util.h"
 #include "config.h"
 #include "cve-string.h"
+#include "cve-db-lock.h"
 #include "core.h"
 
 #include "update.h"
@@ -38,127 +35,6 @@
 #include "fetch.h"
 
 #define UPDATE_THRESHOLD 7200
-/* Wait at most 5 minutes for a parallel client */
-#define UPDATE_WAIT 300
-
-static bool do_unlock(void);
-
-static bool reg = false;
-static gchar *lock_file;
-static volatile int lock_fd = -1;
-
-static gchar *get_lock_file(const gchar *db_dir)
-{
-        return g_build_path(G_DIR_SEPARATOR_S, db_dir, "nvd.lock", NULL);
-}
-
-static void exit_unlock(void)
-{
-        if (lock_fd > 0 && !do_unlock()) {
-                fprintf(stderr, "exit_unlock(): Failed to unlock cleanly\n");
-        }
-}
-
-static void exit_unlock_sig(int sig)
-{
-        exit_unlock();
-        exit(sig);
-}
-
-static bool do_lock(const gchar *lfile)
-{
-        struct flock lock = { .l_type = F_WRLCK, };
-        int fd;
-
-        lfile = g_strdup(lfile);
-        if (!lfile) {
-                goto err_out;
-        }
-
-        fd = open(lfile, O_WRONLY|O_CREAT|O_NONBLOCK, S_IRUSR|S_IWUSR);
-        if (fd < 0) {
-                goto err_free;
-        }
-
-        if (fcntl(fd, F_SETLK, &lock)) {
-                goto err_lock;
-        }
-
-        /* Lock aquired, store lock configuration before registering
-         * signal and atexit() handlers to let them unconfigure
-         * gracefully.
-         */
-        lock_file = lfile;
-        lock_fd = fd;
-
-        if (!reg) {
-                reg = true;
-                signal(SIGINT, exit_unlock_sig);
-                atexit(exit_unlock);
-        }
-
-        return true;
-
-err_lock:
-        /* File existence is enough */
-        fprintf(stderr, "do_lock(): Failed to gain exclusive lock: %s\n", strerror(errno));
-        close(fd);
-err_free:
-        g_free(lfile);
-err_out:
-        return false;
-}
-
-
-static bool do_unlock()
-{
-        struct flock lock = { 0 };
-        bool ret = true;
-
-        if (lock_fd < 0) {
-                return false;
-        }
-
-        /* Release it */
-        lock.l_type = F_UNLCK;
-        if (fcntl(lock_fd, F_SETLK, &lock) < 0) {
-                close(lock_fd);
-                fprintf(stderr, "do_unlock(): Unable to unlock file: %s\n", strerror(errno));
-                ret = false;
-        }
-
-        close(lock_fd);
-        lock_fd = -1;
-
-        if (unlink(lock_file) != 0) {
-                fprintf(stderr, "do_unlock(): Lockfile not removed, will cause issues.");
-                ret = false;
-        }
-
-        g_free(lock_file);
-        lock_file = NULL;
-
-        return ret;
-}
-
-static bool wait_file(gchar *path, int timeout)
-{
-        int elapsed = 0;
-
-        fprintf(stderr, "Waiting for another instance of cve-check-tool to finish updating\n");
-
-        while (true) {
-                if (!cve_file_exists(path)) {
-                        return true;
-                }
-                if (elapsed >= timeout) {
-                        return false;
-                }
-                /* Sure, it's fuzzy, but we don't need that kind of granularity */
-                sleep(1);
-                elapsed += 1;
-        }
-}
 
 gchar *get_db_path(const gchar *path)
 {
@@ -171,15 +47,10 @@ gchar *get_db_path(const gchar *path)
         return g_build_path(G_DIR_SEPARATOR_S, path, nvds, nvd_file, NULL);
 }
 
-static bool __update_required(const char *db_file, const char *lfile)
+static bool __update_required(const char *db_file)
 {
         struct stat st;
         time_t t;
-
-        memset(&st, 0, sizeof(st));
-        if (stat(lfile, &st)) {
-                return true;
-        }
 
         memset(&st, 0, sizeof(st));
         if (stat(db_file, &st)) {
@@ -196,20 +67,7 @@ static bool __update_required(const char *db_file, const char *lfile)
 
 int update_required(const char *db_file)
 {
-        autofree(gchar) *db_dir = NULL;
-        autofree(gchar) *lfile = NULL;
-
-        db_dir = g_path_get_dirname(db_file);
-        if (!db_dir) {
-                return -1;
-        }
-
-        lfile = get_lock_file(db_dir);
-        if (!lfile) {
-                return -1;
-        }
-
-        return __update_required(db_file, lfile);
+        return __update_required(db_file);
 }
 
 bool update_db(bool quiet, const char *db_file)
@@ -217,31 +75,27 @@ bool update_db(bool quiet, const char *db_file)
         autofree(gchar) *db_dir = NULL;
         autofree(CveDB) *cve_db = NULL;
         autofree(GDateTime) *date = NULL;
-        autofree(gchar) *lfile = NULL;
         int year;
         bool ret = false;
         bool db_exist = false;
+        bool db_locked;
+
+        db_locked = cve_db_write_lock(LOCK_WAIT_SECS);
+        if (!db_locked) {
+                fputs("Exiting...\n", stderr);
+                goto end_no_lock;
+        }
+
+        /* Lock aquired, check if database is still needs update */
+        if (!__update_required(db_file)) {
+                ret = true;
+                goto end;
+        }
 
         db_dir = g_path_get_dirname(db_file);
         if (!db_dir) {
                 fprintf(stderr, "update_db(): Out of memory\n");
                 goto end;
-        }
-
-        lfile = get_lock_file(db_dir);
-        if (!lfile) {
-                fprintf(stderr, "update_db(): Out of memory\n");
-                goto end;
-        }
-
-        if (cve_file_exists(lfile)) {
-                if (!wait_file(lfile, UPDATE_WAIT)) {
-                        fprintf(stderr, "update_db(): Waited too long for parallel update\n");
-                        goto end;
-                }
-                if (!__update_required(db_file, lfile)) {
-                        return true;
-                }
         }
 
         db_exist = cve_file_exists(db_file);
@@ -250,12 +104,6 @@ bool update_db(bool quiet, const char *db_file)
                         fprintf(stderr, "Unable to create required directory: %s\n", db_dir);
                         goto end;
                 }
-        }
-
-        /* Go and lock now. */
-        if (!do_lock(lfile)) {
-                fprintf(stderr, "update_db(): Cannot get lock file\n");
-                return false;
         }
 
         cve_db = cve_db_new(db_file);
@@ -314,8 +162,8 @@ bool update_db(bool quiet, const char *db_file)
         ret = true;
 
 end:
-        do_unlock();
-
+        cve_db_unlock();
+end_no_lock:
         return ret;
 }
 

--- a/src/update.c
+++ b/src/update.c
@@ -129,11 +129,9 @@ static inline int update_begin(const char *update_fname)
 
 static inline void update_end(int fd, const char *update_fname, bool ok)
 {
-        if (fd >= 0) {
-                close(fd);
-                if (ok) {
-                        unlink(update_fname);
-                }
+        close(fd);
+        if (ok) {
+                unlink(update_fname);
         }
 }
 
@@ -147,29 +145,27 @@ bool update_db(bool quiet, const char *db_file)
         int year;
         bool ret = false;
         bool db_exist = false;
-        bool db_locked;
+        bool db_locked = false;
 
         u_fname = make_db_dot_fname(db_file, UPDATE_DB_MARKER_SUFFIX);
         if (!u_fname) {
-                fputs("update_db(): Out of memory\n", stderr);
-                goto end_no_lock;
+                goto oom;
+        }
+
+        db_dir = g_path_get_dirname(db_file);
+        if (!db_dir) {
+                goto oom;
         }
 
         db_locked = cve_db_write_lock(LOCK_WAIT_SECS);
         if (!db_locked) {
                 fputs("Exiting...\n", stderr);
-                goto end_no_lock;
+                goto end;
         }
 
         /* Lock aquired, check if database is still needs update */
         if (!__update_required(db_file, u_fname->str)) {
                 ret = true;
-                goto end;
-        }
-
-        db_dir = g_path_get_dirname(db_file);
-        if (!db_dir) {
-                fprintf(stderr, "update_db(): Out of memory\n");
                 goto end;
         }
 
@@ -202,6 +198,10 @@ bool update_db(bool quiet, const char *db_file)
                 } else {
                         uri = g_strdup_printf("%s/nvdcve-2.0-%d.xml.gz", URI_PREFIX, i);
                         target = g_strdup_printf("%s/nvdcve-2.0-%d.xml.gz", db_dir, i);
+                }
+
+                if (!uri || !target) {
+                        goto oom;
                 }
 
                 st = fetch_uri(uri, target, !quiet);
@@ -244,10 +244,16 @@ bool update_db(bool quiet, const char *db_file)
 
         ret = true;
 end:
-        update_end(u_handle, u_fname->str, ret);
-        cve_db_unlock();
-end_no_lock:
+        if (u_handle >= 0) {
+                update_end(u_handle, u_fname->str, ret);
+        }
+        if (db_locked) {
+                cve_db_unlock();
+        }
         return ret;
+oom:
+        fputs("update_db(): Out of memory\n", stderr);
+        goto end;
 }
 
 /*

--- a/src/update.c
+++ b/src/update.c
@@ -12,6 +12,7 @@
 #define _GNU_SOURCE
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/mman.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -24,6 +25,7 @@
 #include <glib.h>
 #include <gio/gio.h>
 #include <curl/curl.h>
+#include <openssl/sha.h>
 
 #include "cve-check-tool.h"
 
@@ -78,6 +80,96 @@ static cve_string *nvdcve_make_fname(int year, const char *fext)
         } else {
                 return cve_string_dup_printf("nvdcve-2.0-%d.%s", year, fext);
         }
+}
+
+static char *nvdcve_meta_get_val(FILE *f, const char *field)
+{
+        do {
+                char field_name[256], field_value[256];
+                int ret;
+
+                ret = fscanf(f, " %255[^: \f\n\r\t\v] :%255s",
+                             field_name, field_value);
+                if (ret != 2) {
+                        if (ret != EOF) {
+                                continue;
+                        }
+                        if (ferror(f)) {
+                                if (errno == EINTR || errno == EAGAIN) {
+                                        clearerr(f);
+                                        continue;
+                                }
+                        }
+                        return NULL;
+                }
+                if (streq(field_name, field)) {
+                        return strdup(field_value);
+                }
+        } while (1);
+}
+
+static bool nvdcve_data_ok(const char *meta, const char *data)
+{
+        autofree(char) *csum_meta = NULL;
+        char csum_data[SHA256_DIGEST_LENGTH * 2 + 1];
+        unsigned char digest[SHA256_DIGEST_LENGTH];
+        struct stat st;
+        int fdata;
+        void *buffer;
+        size_t length;
+        FILE *fmeta;
+        bool ret = false;
+
+        /* Get digest from the NVD META file */
+        fmeta = fopen(meta, "r");
+        if (!fmeta) {
+                goto err_out;
+        }
+
+        csum_meta = nvdcve_meta_get_val(fmeta, "sha256");
+        if (!csum_meta) {
+                goto err_fclose;
+        }
+
+        /* Compute digest on NVD XML file */
+        fdata = open(data, O_RDONLY);
+        if (fdata < 0) {
+                goto err_fclose;
+        }
+
+        memset(&st, 0, sizeof(st));
+        if (fstat(fdata, &st)) {
+                goto err_close;
+        }
+        length = st.st_size;
+
+        buffer = mmap(NULL, length, PROT_READ, MAP_PRIVATE, fdata, 0);
+        if (!buffer) {
+                goto err_close;
+        }
+
+        if (!SHA256(buffer, length, digest)) {
+                goto err_unmap;
+        }
+
+        for (size_t i = 0; i < sizeof(digest); i++) {
+                size_t idx = i * 2;
+                size_t len = sizeof(csum_data) - idx;
+
+                snprintf(&csum_data[idx], len, "%02hhx", digest[i]);
+        }
+
+        ret = streq(csum_meta, csum_data);
+
+err_unmap:
+        munmap(buffer, length);
+err_close:
+        close(fdata);
+err_fclose:
+        fclose(fmeta);
+err_out:
+        return ret;
+
 }
 
 static bool __update_required(const char *db_file, const char *update_fname)
@@ -148,55 +240,122 @@ static int do_fetch_update(int year, const char *db_dir, CveDB *cve_db,
                            bool db_exist, bool verbose)
 {
         const char nvd_uri[] = URI_PREFIX;
-        autofree(cve_string) *uri = NULL;
-        autofree(cve_string) *target = NULL;
+        autofree(cve_string) *uri_meta = NULL;
+        autofree(cve_string) *uri_data_gz = NULL;
+        autofree(cve_string) *nvdcve_meta = NULL;
+        autofree(cve_string) *nvdcve_data = NULL;
+        autofree(cve_string) *nvdcve_data_gz = NULL;
+        autofree(cve_string) *nvd_xml = NULL;
         autofree(cve_string) *nvd_xml_gz = NULL;
+        autofree(cve_string) *nvd_meta = NULL;
         FetchStatus st;
-        bool update = false;
+        bool update, load, refetched = false;
 
-        nvd_xml_gz = nvdcve_make_fname(year, "xml.gz");
+        /* Prepare NVD META file/uri pathes */
+        nvd_meta = nvdcve_make_fname(year, "meta");
+        if (!nvd_meta) {
+                return ENOMEM;
+        }
+
+        nvdcve_meta = cve_string_dup_printf("%s/%s", db_dir, nvd_meta->str);
+        if (!nvdcve_meta) {
+                return ENOMEM;
+        }
+
+        uri_meta = cve_string_dup_printf("%s/%s", nvd_uri, nvd_meta->str);
+        if (!uri_meta) {
+                return ENOMEM;
+        }
+
+        /* Prepare NVD XML file/uri pathes */
+        nvd_xml = nvdcve_make_fname(year, "xml");
+        if (!nvd_xml) {
+                return ENOMEM;
+        }
+
+        nvdcve_data = cve_string_dup_printf("%s/%s", db_dir, nvd_xml->str);
+        if (!nvdcve_data) {
+                return ENOMEM;
+        }
+
+        nvd_xml_gz = cve_string_dup_printf("%s.gz", nvd_xml->str);
         if (!nvd_xml_gz) {
                 return ENOMEM;
         }
 
-        target = cve_string_dup_printf("%s/%s", db_dir, nvd_xml_gz->str);
-        if (!target) {
+        nvdcve_data_gz = cve_string_dup_printf("%s/%s", db_dir, nvd_xml_gz->str);
+        if (!nvdcve_data_gz) {
                 return ENOMEM;
         }
 
-        uri = cve_string_dup_printf("%s/%s", nvd_uri, nvd_xml_gz->str);
-        if (!uri) {
+        uri_data_gz = cve_string_dup_printf("%s/%s", nvd_uri, nvd_xml_gz->str);
+        if (!uri_data_gz) {
                 return ENOMEM;
         }
 
-        st = fetch_uri(uri->str, target->str, verbose);
+refetch:
+        if (refetched) {
+                unlink(nvdcve_meta->str);
+                unlink(nvdcve_data->str);
+                unlink(nvdcve_data_gz->str);
+        }
+
+        /* Fetch NVD META file */
+        st = fetch_uri(uri_meta->str, nvdcve_meta->str, verbose);
+        if (st == FETCH_STATUS_FAIL) {
+                fprintf(stderr, "Failed to fetch %s\n", uri_meta->str);
+                return -1;
+        }
+
+        /* Fetch NVD XML file */
+        st = fetch_uri(uri_data_gz->str, nvdcve_data_gz->str, verbose);
         switch (st) {
         case FETCH_STATUS_FAIL:
-                fprintf(stderr, "Failed to fetch %s\n", uri->str);
+                fprintf(stderr, "Failed to fetch %s\n", uri_data_gz->str);
                 return -1;
         case FETCH_STATUS_UPDATE:
-                update = true;
+                update = load = true;
                 break;
         default:
-                if (verbose) {
-                        fprintf(stderr, "Skipping: %s\n", nvd_xml_gz->str);
-                }
+                update = !nvdcve_data_ok(nvdcve_meta->str, nvdcve_data->str);
+                load = !db_exist;
                 break;
         }
 
-        if (update || !db_exist) {
-                /* Only load on updates */
-                if (!gunzip_file(target->str)) {
-                        fprintf(stderr, "Unable to extract %s\n", target->str);
+        if (update) {
+                if (!gunzip_file(nvdcve_data_gz->str)) {
+                        if (!refetched) {
+                                refetched = true;
+                                goto refetch;
+                        }
+                        fprintf(stderr, "Unable to extract %s\n",
+                                nvdcve_data_gz->str);
                         return -1;
                 }
-                if (!cve_db_load(cve_db, target->str)) {
-                        fprintf(stderr, "\nUnable to find: %s\n", target->str);
+                if (!nvdcve_data_ok(nvdcve_meta->str, nvdcve_data->str)) {
+                        if (!refetched) {
+                                refetched = true;
+                                goto refetch;
+                        }
+                        fprintf(stderr, "Unpacked data %s is not consistent\n",
+                                nvdcve_data->str);
                         return -1;
                 }
-                if (verbose) {
-                        fprintf(stderr, "Loaded: %s\n", nvd_xml_gz->str);
+        }
+
+        if (load) {
+                if (!cve_db_load(cve_db, nvdcve_data->str)) {
+                        fprintf(stderr, "\nUnable to load: %s\n", nvdcve_data->str);
+                        return -1;
                 }
+        }
+
+        if (verbose) {
+                static const char data_report_msg[][sizeof("Skipp")] = {
+                        [false] = "Skipp",
+                        [true]  = "Load",
+                };
+                fprintf(stderr, "%sed: %s\n", data_report_msg[load], nvd_xml_gz->str);
         }
 
         return 0;

--- a/src/update.h
+++ b/src/update.h
@@ -14,11 +14,11 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+gchar *get_db_path(const gchar *path);
 
-bool update_required(void);
-gchar *get_lock_file(void);
+int update_required(const char *db_file);
 
-bool update_db(bool quiet);
+bool update_db(bool quiet, const char *db_file);
 
 
 /*

--- a/tests/check-template.c
+++ b/tests/check-template.c
@@ -20,14 +20,14 @@
 
 START_TEST(cve_template_basic)
 {
-        gchar *ret = NULL;
+        cve_string *ret = NULL;
         GHashTable *table = NULL;
 
         const char *unchanged = "I have no {{hashtable}}";
         ret = template_string(unchanged, NULL);
         fail_if(!ret, "No return string");
-        fail_if(!g_str_equal(unchanged, ret), "Differing string for no hashtable");
-        free(ret);
+        fail_if(!cve_string_const_equal(ret, unchanged), "Differing string for no hashtable");
+        cve_string_free(ret);
 
         table = g_hash_table_new(g_str_hash, g_str_equal);
         fail_if(!table, "Unable to allocate table");
@@ -41,8 +41,8 @@ START_TEST(cve_template_basic)
         const char *exp = "Frodo Baggins was a curious Hobbit. With hindsight it is likely he would have avoided Mordor.";
         ret = template_string(str, table);
         fail_if(!ret, "Unable to allocate string");
-        fail_if(!g_str_equal(ret, exp), "Built string does not match expected template output");
-        g_free(ret);
+        fail_if(!cve_string_const_equal(ret, exp), "Built string does not match expected template output");
+        cve_string_free(ret);
 
         g_hash_table_unref(table);
 }
@@ -52,7 +52,7 @@ START_TEST(cve_template_context)
 {
         TemplateContext *top = NULL;
         TemplateContext *child = NULL;
-        gchar *ret = NULL;
+        cve_string *ret = NULL;
 
         top = template_context_new();
         fail_if(!top, "Failed to allocate TemplateContext");
@@ -63,20 +63,19 @@ START_TEST(cve_template_context)
         template_context_add_string(child, "number", "42");
         template_context_add_subcontext(top, "section", child);
 
-        char *input = "The name is {{name}}{{#norender}}Output{{/norender}}{{#section}} {{name}} {{number}}{{/section}}";
-        char *exp = "The name is correctname correctname 42";
+        const char *input = "The name is {{name}}{{#norender}}Output{{/norender}}{{#section}} {{name}} {{number}}{{/section}}";
+        const char *exp = "The name is correctname correctname 42";
 
         ret = template_context_process_line(top, input, false);
         fail_if(!ret, "Failed to get return fro template_context_process_line");
-
-        fail_if(!g_str_equal(ret, exp), "Returned context string does not match expected template output");
-        g_free(ret);
+        fail_if(!cve_string_const_equal(ret, exp), "Returned context string does not match expected template output");
+        cve_string_free(ret);
 
         /* HTMLish */
         input = "table a:visited { color: #999999 ; }";
         ret = template_context_process_line(top, input, false);
-        fail_if(!g_str_equal(ret, input), "Returned context string does not match expected Style template output");
-        g_free(ret);
+        fail_if(!cve_string_const_equal(ret, input), "Returned context string does not match expected Style template output");
+        cve_string_free(ret);
 
         template_context_free(top);
 
@@ -87,8 +86,8 @@ START_TEST(cve_template_context)
         template_context_add_bool(top, "bool1", false);
         template_context_add_bool(top, "bool2", true);
         ret = template_context_process_line(top, input, false);
-        fail_if(!g_str_equal(ret, exp), "Return context (boolean) string does not match expected output");
-        g_free(ret);
+        fail_if(!cve_string_const_equal(ret, exp), "Return context (boolean) string does not match expected output");
+        cve_string_free(ret);
 
         template_context_free(top);
 }
@@ -96,7 +95,7 @@ END_TEST
 
 START_TEST(cve_template_fails)
 {
-        char *ret = NULL;
+        cve_string *ret = NULL;
         GHashTable *table = NULL;
 
         table = g_hash_table_new(g_str_hash, g_str_equal);
@@ -106,25 +105,25 @@ START_TEST(cve_template_fails)
 
         const char *msg = "This is {{failure 1";
         /* Expected this will be stripped */
-        char *exp = "This is {{failure 1";
+        const char *exp = "This is {{failure 1";
         ret = template_string(msg, table);
         fail_if(!ret, "Unable to allocate string");
-        fail_if(!g_str_equal(ret, exp), "Differing return string");
-        free(ret);
+        fail_if(!cve_string_const_equal(ret, exp), "Differing return string");
+        cve_string_free(ret);
 
         msg = "This is {{failure }2";
         exp = "This is {{failure }2";
         ret = template_string(msg, table);
         fail_if(!ret, "Unable to allocate string");
-        fail_if(!g_str_equal(ret, exp), "Differing return string #2");
-        free(ret);
+        fail_if(!cve_string_const_equal(ret, exp), "Differing return string #2");
+        cve_string_free(ret);
 
         msg = "This is {{failure}} {{test}}!";
         exp = "This is onoes !";
         ret = template_string(msg, table);
         fail_if(!ret, "Unable to allocate string");
-        fail_if(!g_str_equal(ret, exp), "Unknown value not collapsed");
-        free(ret);
+        fail_if(!cve_string_const_equal(ret, exp), "Unknown value not collapsed");
+        cve_string_free(ret);
 
         g_hash_table_unref(table);
 }
@@ -134,7 +133,8 @@ START_TEST(cve_template_list)
 {
         TemplateContext *top = NULL;
         TemplateContext *node = NULL;
-        char *exp = NULL, *ret = NULL;
+        const char *exp = NULL;
+        cve_string *ret = NULL;
 
         top = template_context_new();
         fail_if(!top, "Failed to allocate TemplateContext");
@@ -157,9 +157,9 @@ START_TEST(cve_template_list)
         exp = "list items: val1 val2 val3 ";
         ret = template_context_process_line(top, "list items: {{#list}}{{key1}} {{/list}}", false);
         fail_if(!ret, "No return from template_context_process_line");
-        fail_if(!g_str_equal(exp, ret), "Returned list string does not match expected output");
+        fail_if(!cve_string_const_equal(ret, exp), "Returned list string does not match expected output");
+        cve_string_free(ret);
 
-        g_free(ret);
         template_context_free(top);
 }
 END_TEST
@@ -167,7 +167,8 @@ END_TEST
 START_TEST(cve_template_bool)
 {
         TemplateContext *top = NULL;
-        char *exp = NULL, *ret = NULL;
+        const char *exp = NULL;
+        cve_string *ret = NULL;
 
         top = template_context_new();
         fail_if(!top, "Failed to allocate TemplateContext");
@@ -179,9 +180,9 @@ START_TEST(cve_template_bool)
         ret = template_context_process_line(top,
                 "His name was {{#conditiontrue}}{{name}}{{/conditiontrue}}{{#nocond}}Jimbob{{/nocond}}: {{conditiontrue}}", false);
         fail_if(!ret, "No return from template_context_process_line");
-        fail_if(!g_str_equal(exp, ret), "Returned bool-test string does not match expected output");
+        fail_if(!cve_string_const_equal(ret, exp), "Returned bool-test string does not match expected output");
+        cve_string_free(ret);
 
-        g_free(ret);
         template_context_free(top);
 }
 END_TEST


### PR DESCRIPTION
This is my v2 series to address various aspects related to the database integrity and results consistency.

I've removed most of the glib dependencies from update.c all from cve-db-lock.c infrastructure,
change template_context_process_line() and template_string() to use/return cve_string to avoid strlen() usage.

Replace glib SHA256 digest routines with ones from openssl and simplify NVD data integrity checks greatly compared to v2 series. Choose minimal supported openssl version as 1.0.0 since 0.9.8 not supported for security updates starting from 2015-01-01.

Tested both compile and runtime for CSV and HTML report generation using meta-security-isafw on YOCTO. Seems everything is work as expected.

Please review and possibly merge. And as always, comments and suggestions are welcome.

Thanks.

