### PR TITLE
util.c: Change logic in cve_get_file_parent()

### DIFF
--- a/src/library/util.c
+++ b/src/library/util.c
@@ -184,11 +184,9 @@ bool cve_is_dir(const char *p)
 
 char *cve_get_file_parent(const char *p)
 {
-        char *r = realpath(p, NULL);
-        if (!r) {
-                return NULL;
-        }
-        return dirname(r);
+        autofree(char) *d = strdup(p);
+        char *r = realpath(dirname(d), NULL);
+        return r;
 }
 
 bool cve_file_set_text(const char *path, char *text)


### PR DESCRIPTION
Function cve_get_file_parent() will try to get the
realpath and the get the dirname. If the file used
to get parent doesn't exist the call will fail.

This problem is present when using another directory
for the database, realpath() won't find the nvd.db
file and the program will exit quitely.

This patch will first get the dirname and the get
the realpath to avoid failing when the doesn't exist.

Signed-off-by: Mariano Lopez <mariano.lopez@linux.intel.com>