### PR TITLE
curl: allow overriding default CA certificate file

### DIFF
--- a/src/library/cve-check-tool.h
+++ b/src/library/cve-check-tool.h
@@ -43,6 +43,7 @@ typedef struct CveCheckTool {
     bool bugs;                          /**<Whether bug tracking is enabled */
     GHashTable *mapping;                /**<CVE Mapping */
     const char *output_file;            /**<Output file, if any */
+    const char *cacert_file;            /**<Non-default SSL certificate file, if any */
 } CveCheckTool;
 
 /**

--- a/src/library/fetch.c
+++ b/src/library/fetch.c
@@ -37,7 +37,7 @@ static size_t write_func(void *ptr, size_t size, size_t nmemb, struct fetch_t *f
         return fwrite(ptr, size, nmemb, f->f);
 }
 
-FetchStatus fetch_uri(const char *uri, const char *target, bool verbose)
+FetchStatus fetch_uri(const char *uri, const char *target, bool verbose, const char *cacert_file)
 {
         FetchStatus ret = FETCH_STATUS_FAIL;
         CURLcode res;
@@ -48,6 +48,13 @@ FetchStatus fetch_uri(const char *uri, const char *target, bool verbose)
         curl = curl_easy_init();
         if (!curl) {
                 return ret;
+        }
+
+        if (cacert_file) {
+                res = curl_easy_setopt(curl, CURLOPT_CAINFO, cacert_file);
+                if (res != CURLE_OK) {
+                        goto bail;
+                }
         }
 
         if (stat(target, &st) == 0) {

--- a/src/library/fetch.h
+++ b/src/library/fetch.h
@@ -28,7 +28,7 @@ typedef enum {
  * @param verbose Whether to be verbose
  * @return A FetchStatus, indicating the operation taken
  */
-FetchStatus fetch_uri(const char *uri, const char *target, bool verbose);
+FetchStatus fetch_uri(const char *uri, const char *target, bool verbose, const char *cacert_file);
 
 /**
  * Attempt to extract the given gzipped file

--- a/src/main.c
+++ b/src/main.c
@@ -282,6 +282,7 @@ static bool csv_mode = false;
 static char *modified_stamp = NULL;
 static gchar *mapping_file = NULL;
 static gchar *output_file = NULL;
+static gchar *cacert_file = NULL;
 
 static GOptionEntry _entries[] = {
         { "not-patched", 'n', 0, G_OPTION_ARG_NONE, &hide_patched, "Hide patched/addressed CVEs", NULL },
@@ -296,6 +297,7 @@ static GOptionEntry _entries[] = {
         { "csv", 'c', 0, G_OPTION_ARG_NONE, &csv_mode, "Output CSV formatted data only", NULL },
         { "mapping", 'M', 0, G_OPTION_ARG_STRING, &mapping_file, "Path to a mapping file", NULL},
         { "output-file", 'o', 0, G_OPTION_ARG_STRING, &output_file, "Path to the output file (output plugin specific)", NULL},
+        { "cacert", 'C', 0, G_OPTION_ARG_STRING, &cacert_file, "Path to the combined SSL certificates file (system default is used if not set)", NULL},
         { .short_name = 0 }
 };
 
@@ -494,6 +496,7 @@ int main(int argc, char **argv)
 
         quiet = csv_mode || !no_html;
         self->output_file = output_file;
+        self->cacert_file = cacert_file;
 
         if (!csv_mode && self->output_file) {
                 quiet = false;
@@ -532,7 +535,7 @@ int main(int argc, char **argv)
                 if (status) {
                         fprintf(stderr, "Update of db forced\n");
                         cve_db_unlock();
-                        if (!update_db(quiet, db_path->str)) {
+                        if (!update_db(quiet, db_path->str, self->cacert_file)) {
                                 fprintf(stderr, "DB update failure\n");
                                 goto cleanup;
                         }

--- a/src/update-main.c
+++ b/src/update-main.c
@@ -43,11 +43,13 @@ the Free Software Foundation; either version 2 of the License, or\n\
 static gchar *nvds = NULL;
 static bool _show_version = false;
 static bool _quiet = false;
+static const char *_cacert_file = NULL;
 
 static GOptionEntry _entries[] = {
         { "nvd-dir", 'd', 0, G_OPTION_ARG_STRING, &nvds, "NVD directory in filesystem", NULL },
         { "version", 'v', 0, G_OPTION_ARG_NONE, &_show_version, "Show version", NULL },
         { "quiet", 'q', 0, G_OPTION_ARG_NONE, &_quiet, "Run silently", NULL },
+        { "cacert", 'C', 0, G_OPTION_ARG_STRING, &_cacert_file, "Path to the combined SSL certificates file (system default is used if not set)", NULL},
         { .short_name = 0 }
 };
 
@@ -88,7 +90,7 @@ int main(int argc, char **argv)
                 goto end;
         }
 
-        if (update_db(_quiet, db_path->str)) {
+        if (update_db(_quiet, db_path->str, _cacert_file)) {
                 ret = EXIT_SUCCESS;
         } else {
                 fprintf(stderr, "Failed to update database\n");

--- a/src/update.c
+++ b/src/update.c
@@ -266,7 +266,7 @@ static inline void update_end(int fd, const char *update_fname, bool ok)
 }
 
 static int do_fetch_update(int year, const char *db_dir, CveDB *cve_db,
-                           bool db_exist, bool verbose)
+                           bool db_exist, bool verbose, const char *cacert_file)
 {
         const char nvd_uri[] = URI_PREFIX;
         autofree(cve_string) *uri_meta = NULL;
@@ -330,14 +330,14 @@ refetch:
         }
 
         /* Fetch NVD META file */
-        st = fetch_uri(uri_meta->str, nvdcve_meta->str, verbose);
+        st = fetch_uri(uri_meta->str, nvdcve_meta->str, verbose, cacert_file);
         if (st == FETCH_STATUS_FAIL) {
                 fprintf(stderr, "Failed to fetch %s\n", uri_meta->str);
                 return -1;
         }
 
         /* Fetch NVD XML file */
-        st = fetch_uri(uri_data_gz->str, nvdcve_data_gz->str, verbose);
+        st = fetch_uri(uri_data_gz->str, nvdcve_data_gz->str, verbose, cacert_file);
         switch (st) {
         case FETCH_STATUS_FAIL:
                 fprintf(stderr, "Failed to fetch %s\n", uri_data_gz->str);
@@ -390,7 +390,7 @@ refetch:
         return 0;
 }
 
-bool update_db(bool quiet, const char *db_file)
+bool update_db(bool quiet, const char *db_file, const char *cacert_file)
 {
         autofree(char) *db_dir = NULL;
         autofree(CveDB) *cve_db = NULL;
@@ -460,7 +460,7 @@ bool update_db(bool quiet, const char *db_file)
                 int y = i > year ? -1 : i;
                 int rc;
 
-                rc = do_fetch_update(y, db_dir, cve_db, db_exist, !quiet);
+                rc = do_fetch_update(y, db_dir, cve_db, db_exist, !quiet, cacert_file);
                 switch (rc) {
                 case 0:
                         continue;

--- a/src/update.h
+++ b/src/update.h
@@ -15,7 +15,7 @@ cve_string *get_db_path(const char *path);
 
 int update_required(const char *db_file);
 
-bool update_db(bool quiet, const char *db_file);
+bool update_db(bool quiet, const char *db_file, const char *cacert_file);
 
 
 /*


### PR DESCRIPTION
Similar to curl, --cacert can now be used in cve-check-tool and
cve-check-update to override the default CA certificate file. Useful
in cases where the system default is unsuitable (for example,
out-dated) or broken (as in OE's current native libcurl, which embeds
a path string from one build host and then uses it on another although
the right path may have become something different - see
https://bugzilla.yoctoproject.org/show_bug.cgi?id=9883).