### PR TITLE
improving the CVE detection rate

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -36,6 +36,7 @@
 
 const char *nvd_file = "nvd.db";
 const char *nvd_dir = "NVDS";
+bool use_frac_compare = false;
 
 struct CveDB {
         /** XML traversal state */
@@ -85,7 +86,7 @@ static bool ensure_table(CveDB *self)
                 free(err);
                 return false;
         }
-        
+
         query = "CREATE TABLE IF NOT EXISTS " TABLE_NAME " "
                 "(ID TEXT UNIQUE, SUMMARY TEXT, SCORE TEXT, MODIFIED INTEGER, VECTOR TEXT);";
         rc = sqlite3_exec(self->db, query, NULL, NULL, &err);
@@ -143,8 +144,46 @@ struct cve_entry_t *cve_db_get_cve(CveDB *self, char *id)
         t->score = g_strdup((const char*)sqlite3_column_text(self->get_cve, 2));
         t->modified = sqlite3_column_int64(self->get_cve, 3);
         t->vector = g_strdup((const char*)sqlite3_column_text(self->get_cve, 4));
-        
+
         return t;
+}
+
+GList *cve_db_get_issues_frac_compare(CveDB *self, char *product, char *version)
+{
+        int rc = 0;
+        GList *list = NULL;
+        int ret = 0;
+
+        if (!self || !self->db)
+                return NULL;
+
+        sqlite3_reset(self->search_product);
+
+        if (sqlite3_bind_text(self->search_product, 1, product, -1, SQLITE_STATIC) != SQLITE_OK) {
+                fprintf(stderr, "cve_db_get_issues_frac_compare(): %s\n", sqlite3_errmsg(self->db));
+                return NULL;
+        }
+
+        while ((rc = sqlite3_step(self->search_product)) == SQLITE_ROW) {
+                if ((const char *)sqlite3_column_text(self->search_product, 1) == NULL) /*skip over (null) product*/
+                        continue;
+                if ((const char *)sqlite3_column_text(self->search_product, 2) == NULL) /*skip over (null) version*/
+                        continue;
+
+                ret = strverscmp(version, (const char *)sqlite3_column_text(self->search_product, 2));
+                if (ret <= 0) { /* our version <= NVD version */
+                        list = g_list_append(list, g_strdup((const char*)sqlite3_column_text(self->search_product, 0)));
+                }
+        }
+
+        if (rc != SQLITE_DONE) {
+                if (list) {
+                        g_list_free_full(list, g_free);
+                        return NULL;
+                }
+        }
+
+        return list;
 }
 
 GList *cve_db_get_issues(CveDB *self,  char *product, char *version)
@@ -594,7 +633,11 @@ CveDB *cve_db_new(const char *path)
         stm = NULL;
 
         /* Search product. */
-        q = "SELECT ID FROM PRODUCTS WHERE PRODUCT = ? AND VERSION = ? COLLATE NOCASE";
+        if (use_frac_compare) {
+                q = "select ID, PRODUCT, VERSION from PRODUCTS where PRODUCT = ?";
+        } else {
+                q = "SELECT ID FROM PRODUCTS WHERE PRODUCT = ? AND VERSION = ? COLLATE NOCASE";
+        }
         rc = sqlite3_prepare_v2(ret->db, q, -1, &stm, NULL);
         if (rc != SQLITE_OK) {
                 fprintf(stderr, "cve_db_new(): %s\n", sqlite3_errmsg(ret->db));
@@ -640,7 +683,7 @@ void cve_db_free(CveDB *self)
      }
      _cve_db_clean(self);
      free(self);
-}   
+}
 
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html

--- a/src/core.h
+++ b/src/core.h
@@ -15,6 +15,7 @@
 
 extern const char *nvd_file;        /* nvd.db */
 extern const char *nvd_dir;         /* NVDS */
+extern bool use_frac_compare;
 
 /**
  * A CVE Database, using the National Vulnerability Database as its source
@@ -84,6 +85,7 @@ struct cve_entry_t *cve_db_get_cve(CveDB *db, char *id);
  * @return A newly allocated list of strings if found, otherwise NULL
  */
 GList *cve_db_get_issues(CveDB *db, char *product, char *version);
+GList *cve_db_get_issues_frac_compare(CveDB *db, char *product, char *version);
 
 /**
  * Util to free a struct cve_entry_t

--- a/src/main.c
+++ b/src/main.c
@@ -66,7 +66,7 @@ static inline void package_free(void *p)
                 pkg_plugin->free_package(t);
                 t->extra = NULL;
         }
-        
+
         if (t->issues) { /* bless you */
                 g_list_free_full(t->issues, xmlFree);
         }
@@ -106,7 +106,13 @@ static void cve_add_package_internal(struct source_package_t *pkg)
         if (self->mapping) {
                 q = g_hash_table_lookup(self->mapping, pkg->name);
         }
-        issues = cve_db_get_issues(self->cve_db, q ? q : pkg->name, pkg->version);
+
+        if (use_frac_compare) {
+                issues = cve_db_get_issues_frac_compare(self->cve_db, q ? q : pkg->name, pkg->version);
+        } else {
+                issues = cve_db_get_issues(self->cve_db, q ? q : pkg->name, pkg->version);
+        }
+
         if (!issues) {
                 goto insert;
         }
@@ -296,6 +302,7 @@ static GOptionEntry _entries[] = {
         { "csv", 'c', 0, G_OPTION_ARG_NONE, &csv_mode, "Output CSV formatted data only", NULL },
         { "mapping", 'M', 0, G_OPTION_ARG_STRING, &mapping_file, "Path to a mapping file", NULL},
         { "output-file", 'o', 0, G_OPTION_ARG_STRING, &output_file, "Path to the output file (output plugin specific)", NULL},
+        { "use-fractional-compare", 'f', 0, G_OPTION_ARG_NONE, &use_frac_compare, "CVE version string fractional compare", NULL },
         { .short_name = 0 }
 };
 


### PR DESCRIPTION
CVE version string fractional compare. False positives might get generated but this can be prevented by implementing blacklist mechanism which contain partial or full CPE, vendor and/or product and/or version.