### PR TITLE
Check for malloc_trim before using it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,8 @@ m4_define([json_required_version], [0.16.0])
 m4_define([openssl_required_version],[1.0.0])
 # TODO: Set minimum sqlite
 
+AC_CHECK_FUNCS_ONCE(malloc_trim)
+
 PKG_CHECK_MODULES(CVE_CHECK_TOOL,
                  [
                   glib-2.0 >= glib_required_version,

--- a/src/core.c
+++ b/src/core.c
@@ -498,9 +498,9 @@ bool cve_db_load(CveDB *self, const char *fname)
         }
 
         b = true;
-
+#ifdef HAVE_MALLOC_TRIM
         malloc_trim(0);
-
+#endif
         xmlFreeTextReader(r);
         if (fd) {
                 close(fd);


### PR DESCRIPTION
malloc_trim is gnu specific and not all libc
implement it, threfore write a configure check
to poke for it first and use the define to
guard its use.

Helps in compiling on musl based systems

Signed-off-by: Khem Raj <raj.khem@gmail.com>