### PR TITLE
Added CVEs with NULL or dash at product version

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -637,7 +637,7 @@ CveDB *cve_db_new(const char *path)
         if (use_frac_compare) {
                 q = "select ID, PRODUCT, VERSION from PRODUCTS where PRODUCT = ?";
         } else {
-                q = "SELECT ID FROM PRODUCTS WHERE PRODUCT = ? AND VERSION = ? COLLATE NOCASE";
+                q = "SELECT ID FROM PRODUCTS WHERE PRODUCT = ? AND (VERSION = ? OR VERSION IS NULL OR VERSION = '-') COLLATE NOCASE";
         }
         rc = sqlite3_prepare_v2(ret->db, q, -1, &stm, NULL);
         if (rc != SQLITE_OK) {


### PR DESCRIPTION
Added CVEs with NULL or dash at product version into the report. These CVEs should be taken into account because in some cases they are valid for the scanned product.
