### PR TITLE
Mark CVE status as Patched in the report

### DIFF
--- a/src/plugins/packaging/rpm/rpm.c
+++ b/src/plugins/packaging/rpm/rpm.c
@@ -163,6 +163,12 @@ struct source_package_t *rpm_inspect_spec(const char *filename)
                                 lpatches = g_list_append(lpatches, g_ascii_strdown(value, -1));
                         }
 
+                        /* Store .patched in the pkg->extra */
+                        if (str_has_isuffix(value, ".patched")) {
+                                lpatches = g_list_append(lpatches, g_ascii_strdown(value, -1));
+                        }
+
+
                 }
 clean:
                 g_free(read);
@@ -203,9 +209,20 @@ bool rpm_is_patched(struct source_package_t *pkg, char *id)
         /* Determine if its patched. */
         autofree(gchar) *pnamet = g_ascii_strdown((gchar*)id, -1);
         autofree(gchar) *pname = g_strdup_printf("%s.patch", pnamet);
+        autofree(gchar) *patched_pname = g_strdup_printf("%s.patched", pnamet);
         if (pkg->extra) {
                 /* Patch validation */
-                return g_list_find_custom(pkg->extra, pname, (GCompareFunc)g_utf8_collate) != NULL;
+
+                if (g_list_find_custom(pkg->extra, pname, (GCompareFunc)g_utf8_collate) != NULL)
+                {
+                        return true;
+                }
+
+                if (g_list_find_custom(pkg->extra, patched_pname, (GCompareFunc)g_utf8_collate) != NULL)
+                {
+                        return true;
+                }
+
         }
         return false;
 }


### PR DESCRIPTION
There are cases when a single patch fixes multiple CVEs and the patch can’t be split into multiple patches. For example, the patch CVE-2011-1000.patch also fixes CVE-2011-1111, but the latter will not appear as “Patched” in the report. For this case we added the support for .patched files, to define custom patches that enable the user to mark a certain CVE as patched without actually applying it.

In order to mark a CVE as patched the user should add a file with the “.patched” extension that contains a detailed description for the reason why the CVE has been marked as patched. Also in the corresponding spec file the user should add the file to the list of patches ( e.g. Patch: CVE-2011-1111.patched)
