### PR TITLE
version mapping support

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -105,6 +105,28 @@ static void cve_add_package_internal(struct source_package_t *pkg)
 
         if (self->mapping) {
                 q = g_hash_table_lookup(self->mapping, pkg->name);
+
+                /*
+                 * overwrite the version from the initial package list
+                 * by the one provided in the mapping file
+                 *
+                 * [Mapping]
+                 * <NAME FOUND IN NVD>,<VERSION FOUND IN NVD> = <OWN PKG NAME>
+                 *
+                 * for example
+                 *
+                 * [Mapping]
+                 * linux_kernel,4.3 = my_own_linux_kernel_name
+                 *
+                 */
+                gchar** temp = g_strsplit(q, ",", -1);
+                if (temp[1] != NULL) {
+                    g_free(q);
+                    q = g_strndup(temp[0], strlen(temp[0]));
+                    g_free(pkg->version);
+                    pkg->version = g_strndup(temp[1], strlen(temp[1]));
+                    g_strfreev(temp);
+                }
         }
 
         if (use_frac_compare) {


### PR DESCRIPTION
Overwrite the version from the initial package list using the version provided in the mapping file.
[Mapping]
name_in_NVD,version_in_NVD = name_from_input_list
For example,
[Mapping]
linux_kernel,4.3 = own_linux_kernel_name
The version of "own_linux_kernel_name" will become by 4.3.
A possible use case is to bridge a custom package version with the one on upstream.
The "local" custom package version might be 4.2-10, coresponding to 4.3 upstream.
So, if we want to catch CVEs for 4.2-10, which actually is 4.3, we append 4.3 as shown above.
