### PR TITLE
update: Compare computed vs expected sha256 digit string ignoring case

### DIFF
--- a/src/update.c
+++ b/src/update.c
@@ -187,7 +187,7 @@ static bool nvdcve_data_ok(const char *meta, const char *data)
                 snprintf(&csum_data[idx], len, "%02hhx", digest[i]);
         }
 
-        ret = streq(csum_meta, csum_data);
+        ret = !strcasecmp(csum_meta, csum_data);
 
 err_unmap:
         munmap(buffer, length);


### PR DESCRIPTION
We produce sha256 digest string using %x snprintf()
qualifier for each byte of digest which uses alphabetic
characters from "a" to "f" in lower case to represent
integer values from 10 to 15.

Previously all of the NVD META files supply sha256
digest string for corresponding XML file in lower case.

However due to some reason this changed recently to
provide digest digits in upper case causing fetched
data consistency checks to fail. This prevents database
from being updated periodically.

While commit c4f6e94 (update: Do not treat sha256 failure
as fatal if requested) adds useful option to skip
digest validation at all and thus provides workaround for
this situation, it might be unacceptable for some
deployments where we need to ensure that downloaded
data is consistent before start parsing it and update
SQLite database.

Use strcasecmp() to compare two digest strings case
insensitively and addressing this case.

Signed-off-by: Sergey Popovich <popovich_sergei@mail.ua>